### PR TITLE
chore: update package name in pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: google_maps_navigation
+name: google_navigation_flutter
 description: A Google Maps Navigation plugin
 repository: https://github.com/googlemaps/flutter-navigation-sdk
 issue_tracker: https://github.com/googlemaps/flutter-navigation-sdk/issues


### PR DESCRIPTION
Migrate from `google_maps_navigation` to `google_navigation_flutter`