### PR TITLE
chore: expose NavigationViewCreationApi to fix static analysis

### DIFF
--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/messages.g.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/messages.g.kt
@@ -1775,7 +1775,7 @@ data class NavInfoDto(
 }
 
 @Suppress("UNCHECKED_CAST")
-private object _NavigationViewCreationApiCodec : StandardMessageCodec() {
+private object NavigationViewCreationApiCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
       128.toByte() -> {
@@ -1832,29 +1832,30 @@ private object _NavigationViewCreationApiCodec : StandardMessageCodec() {
 }
 
 /**
- * Pigeon only generates messages if the messages are used in API. [MapOptionsDto] is encoded and
- * decoded directly to generate a PlatformView creation message. This API should never be used
- * directly.
+ * Pigeon only generates messages if the messages are used in API. [ViewCreationOptionsDto] is
+ * encoded and decoded directly to generate a PlatformView creation message.
+ *
+ * This API should never be used directly.
  *
  * Generated interface from Pigeon that represents a handler of messages from Flutter.
  */
-interface _NavigationViewCreationApi {
-  fun _create(msg: ViewCreationOptionsDto)
+interface NavigationViewCreationApi {
+  fun create(msg: ViewCreationOptionsDto)
 
   companion object {
-    /** The codec used by _NavigationViewCreationApi. */
-    val codec: MessageCodec<Any?> by lazy { _NavigationViewCreationApiCodec }
+    /** The codec used by NavigationViewCreationApi. */
+    val codec: MessageCodec<Any?> by lazy { NavigationViewCreationApiCodec }
     /**
-     * Sets up an instance of `_NavigationViewCreationApi` to handle messages through the
+     * Sets up an instance of `NavigationViewCreationApi` to handle messages through the
      * `binaryMessenger`.
      */
     @Suppress("UNCHECKED_CAST")
-    fun setUp(binaryMessenger: BinaryMessenger, api: _NavigationViewCreationApi?) {
+    fun setUp(binaryMessenger: BinaryMessenger, api: NavigationViewCreationApi?) {
       run {
         val channel =
           BasicMessageChannel<Any?>(
             binaryMessenger,
-            "dev.flutter.pigeon.google_navigation_flutter._NavigationViewCreationApi._create",
+            "dev.flutter.pigeon.google_navigation_flutter.NavigationViewCreationApi.create",
             codec
           )
         if (api != null) {
@@ -1863,7 +1864,7 @@ interface _NavigationViewCreationApi {
             val msgArg = args[0] as ViewCreationOptionsDto
             var wrapped: List<Any?>
             try {
-              api._create(msgArg)
+              api.create(msgArg)
               wrapped = listOf<Any?>(null)
             } catch (exception: Throwable) {
               wrapped = wrapError(exception)

--- a/ios/Classes/messages.g.swift
+++ b/ios/Classes/messages.g.swift
@@ -1696,7 +1696,7 @@ struct NavInfoDto {
   }
 }
 
-private class _NavigationViewCreationApiCodecReader: FlutterStandardReader {
+private class NavigationViewCreationApiCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
     case 128:
@@ -1717,7 +1717,7 @@ private class _NavigationViewCreationApiCodecReader: FlutterStandardReader {
   }
 }
 
-private class _NavigationViewCreationApiCodecWriter: FlutterStandardWriter {
+private class NavigationViewCreationApiCodecWriter: FlutterStandardWriter {
   override func writeValue(_ value: Any) {
     if let value = value as? CameraPositionDto {
       super.writeByte(128)
@@ -1743,55 +1743,57 @@ private class _NavigationViewCreationApiCodecWriter: FlutterStandardWriter {
   }
 }
 
-private class _NavigationViewCreationApiCodecReaderWriter: FlutterStandardReaderWriter {
+private class NavigationViewCreationApiCodecReaderWriter: FlutterStandardReaderWriter {
   override func reader(with data: Data) -> FlutterStandardReader {
-    _NavigationViewCreationApiCodecReader(data: data)
+    NavigationViewCreationApiCodecReader(data: data)
   }
 
   override func writer(with data: NSMutableData) -> FlutterStandardWriter {
-    _NavigationViewCreationApiCodecWriter(data: data)
+    NavigationViewCreationApiCodecWriter(data: data)
   }
 }
 
-class _NavigationViewCreationApiCodec: FlutterStandardMessageCodec {
+class NavigationViewCreationApiCodec: FlutterStandardMessageCodec {
   static let shared =
-    _NavigationViewCreationApiCodec(readerWriter: _NavigationViewCreationApiCodecReaderWriter())
+    NavigationViewCreationApiCodec(readerWriter: NavigationViewCreationApiCodecReaderWriter())
 }
 
 /// Pigeon only generates messages if the messages are used in API.
-/// [MapOptionsDto] is encoded and decoded directly to generate
-/// a PlatformView creation message. This API should never be used directly.
+/// [ViewCreationOptionsDto] is encoded and decoded directly to generate a
+/// PlatformView creation message.
+///
+/// This API should never be used directly.
 ///
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
-protocol _NavigationViewCreationApi {
-  func _create(msg: ViewCreationOptionsDto) throws
+protocol NavigationViewCreationApi {
+  func create(msg: ViewCreationOptionsDto) throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-enum _NavigationViewCreationApiSetup {
-  /// The codec used by _NavigationViewCreationApi.
-  static var codec: FlutterStandardMessageCodec { _NavigationViewCreationApiCodec.shared }
-  /// Sets up an instance of `_NavigationViewCreationApi` to handle messages through the
+class NavigationViewCreationApiSetup {
+  /// The codec used by NavigationViewCreationApi.
+  static var codec: FlutterStandardMessageCodec { NavigationViewCreationApiCodec.shared }
+  /// Sets up an instance of `NavigationViewCreationApi` to handle messages through the
   /// `binaryMessenger`.
-  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: _NavigationViewCreationApi?) {
-    let _createChannel = FlutterBasicMessageChannel(
-      name: "dev.flutter.pigeon.google_navigation_flutter._NavigationViewCreationApi._create",
+  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: NavigationViewCreationApi?) {
+    let createChannel = FlutterBasicMessageChannel(
+      name: "dev.flutter.pigeon.google_navigation_flutter.NavigationViewCreationApi.create",
       binaryMessenger: binaryMessenger,
       codec: codec
     )
     if let api {
-      _createChannel.setMessageHandler { message, reply in
+      createChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let msgArg = args[0] as! ViewCreationOptionsDto
         do {
-          try api._create(msg: msgArg)
+          try api.create(msg: msgArg)
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))
         }
       }
     } else {
-      _createChannel.setMessageHandler(nil)
+      createChannel.setMessageHandler(nil)
     }
   }
 }
@@ -2026,7 +2028,7 @@ protocol MapViewApi {
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-enum MapViewApiSetup {
+class MapViewApiSetup {
   /// The codec used by MapViewApi.
   static var codec: FlutterStandardMessageCodec { MapViewApiCodec.shared }
   /// Sets up an instance of `MapViewApi` to handle messages through the `binaryMessenger`.
@@ -3935,7 +3937,7 @@ protocol ImageRegistryApi {
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-enum ImageRegistryApiSetup {
+class ImageRegistryApiSetup {
   /// The codec used by ImageRegistryApi.
   static var codec: FlutterStandardMessageCodec { ImageRegistryApiCodec.shared }
   /// Sets up an instance of `ImageRegistryApi` to handle messages through the `binaryMessenger`.
@@ -4586,7 +4588,7 @@ protocol NavigationSessionApi {
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-enum NavigationSessionApiSetup {
+class NavigationSessionApiSetup {
   /// The codec used by NavigationSessionApi.
   static var codec: FlutterStandardMessageCodec { NavigationSessionApiCodec.shared }
   /// Sets up an instance of `NavigationSessionApi` to handle messages through the
@@ -5613,7 +5615,7 @@ protocol NavigationInspector {
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-enum NavigationInspectorSetup {
+class NavigationInspectorSetup {
   /// The codec used by NavigationInspector.
   /// Sets up an instance of `NavigationInspector` to handle messages through the `binaryMessenger`.
   static func setUp(binaryMessenger: FlutterBinaryMessenger, api: NavigationInspector?) {

--- a/lib/src/method_channel/messages.g.dart
+++ b/lib/src/method_channel/messages.g.dart
@@ -1908,8 +1908,8 @@ class NavInfoDto {
   }
 }
 
-class __NavigationViewCreationApiCodec extends StandardMessageCodec {
-  const __NavigationViewCreationApiCodec();
+class _NavigationViewCreationApiCodec extends StandardMessageCodec {
+  const _NavigationViewCreationApiCodec();
   @override
   void writeValue(WriteBuffer buffer, Object? value) {
     if (value is CameraPositionDto) {
@@ -1957,22 +1957,24 @@ class __NavigationViewCreationApiCodec extends StandardMessageCodec {
 }
 
 /// Pigeon only generates messages if the messages are used in API.
-/// [MapOptionsDto] is encoded and decoded directly to generate
-/// a PlatformView creation message. This API should never be used directly.
-class _NavigationViewCreationApi {
-  /// Constructor for [_NavigationViewCreationApi].  The [binaryMessenger] named argument is
+/// [ViewCreationOptionsDto] is encoded and decoded directly to generate a
+/// PlatformView creation message.
+///
+/// This API should never be used directly.
+class NavigationViewCreationApi {
+  /// Constructor for [NavigationViewCreationApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  _NavigationViewCreationApi({BinaryMessenger? binaryMessenger})
+  NavigationViewCreationApi({BinaryMessenger? binaryMessenger})
       : __pigeon_binaryMessenger = binaryMessenger;
   final BinaryMessenger? __pigeon_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec =
-      __NavigationViewCreationApiCodec();
+      _NavigationViewCreationApiCodec();
 
-  Future<void> _create(ViewCreationOptionsDto msg) async {
+  Future<void> create(ViewCreationOptionsDto msg) async {
     const String __pigeon_channelName =
-        'dev.flutter.pigeon.google_navigation_flutter._NavigationViewCreationApi._create';
+        'dev.flutter.pigeon.google_navigation_flutter.NavigationViewCreationApi.create';
     final BasicMessageChannel<Object?> __pigeon_channel =
         BasicMessageChannel<Object?>(
       __pigeon_channelName,

--- a/pigeons/messages.dart
+++ b/pigeons/messages.dart
@@ -131,13 +131,13 @@ class ViewCreationOptionsDto {
 }
 
 /// Pigeon only generates messages if the messages are used in API.
-/// [MapOptionsDto] is encoded and decoded directly to generate
-/// a PlatformView creation message. This API should never be used directly.
+/// [ViewCreationOptionsDto] is encoded and decoded directly to generate a
+/// PlatformView creation message.
+///
+/// This API should never be used directly.
 @HostApi()
-// ignore: unused_element
-abstract class _NavigationViewCreationApi {
-  // ignore: unused_element
-  void _create(ViewCreationOptionsDto msg);
+abstract class NavigationViewCreationApi {
+  void create(ViewCreationOptionsDto msg);
 }
 
 enum MapTypeDto { none, normal, satellite, terrain, hybrid }


### PR DESCRIPTION
Fixes issues with static analysis done with `pana`.
As pana does not follow the `exclude` files in analysis_options file, it analyses the generated pigeon output files.
Currently the package has unused NavigationViewCreationApi that is needed for pigeon to generate the needed NavigationViewCreationOptionsDto message. Pigeon won't generate any objects that are not used in API's.
NavigationViewCreationApi itself is not ment to be used, and was marked private with "_" prefix, causing `unused_element` static analysis errors with pana.
as, messages.g.dart is not exposed from the plugin to the app-facing api, it is not a big issue at the moment.
This should be revisited on next pigeon upgrade.

- [ ] Tests pass
- [x] Appropriate changes to documentation are included in the PR