### PR TITLE
docs: fix code snippets in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ class _NavigationSampleState extends State<NavigationSample> {
 
   Future<void> _initializeNavigationSession() async {
     if (!await GoogleMapsNavigator.areTermsAccepted()) {
-      await GoogleMapsNavigationManager.showTermsAndConditionsDialog(
+      await GoogleMapsNavigator.showTermsAndConditionsDialog(
         'Example title',
         'Example company',
       );

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains a Flutter plugin that provides a [Google Navigation](ht
 
 1. To add the Google Navigation for Flutter package to your project, use the command:
   ```
-  pub add google_navigation_flutter
+  flutter pub add google_navigation_flutter
   ```
 
 2. Set the minimum platform version for the platform(s) targeted by your app.


### PR DESCRIPTION
I tried following the example in README.md and ran into two small issues.

1. The `pub` command is typically accessed through `flutter` instead of directly. On fresh Flutter installs, `pub add ...` returns `bash: pub: command not found`
2. `GoogleMapsNavigationManager` doesn't exist.  I believe this is the old name before the class was renamed / reorganized to `GoogleMapsNavigator`.