### PR TITLE
fix: showStopLights and showDestinationMarkers functionality on iOS

### DIFF
--- a/example/lib/pages/navigation.dart
+++ b/example/lib/pages/navigation.dart
@@ -800,7 +800,11 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
 
     return Destinations(
       waypoints: _waypoints,
-      displayOptions: NavigationDisplayOptions(showDestinationMarkers: false),
+      displayOptions: NavigationDisplayOptions(
+        showDestinationMarkers: false,
+        showStopSigns: true,
+        showTrafficLights: true,
+      ),
       routingOptions: RoutingOptions(travelMode: _travelMode),
     );
   }

--- a/ios/Classes/GoogleMapsNavigationView.swift
+++ b/ios/Classes/GoogleMapsNavigationView.swift
@@ -406,7 +406,7 @@ class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettledDelega
   }
 
   func showStopSigns(show: Bool) {
-    _navigationView.settings.showsDestinationMarkers = show
+    _navigationView.settings.showsStopSigns = show
   }
 
   func isNavigationTripProgressBarEnabled() throws -> Bool {


### PR DESCRIPTION
Fixes DisplayOptions.showStopSigns and DisplayOptions.showsDestinationMarkers behaviour on iOS platform

<img width="298" alt="Screenshot 2024-10-08 at 14 57 08" src="https://github.com/user-attachments/assets/35a12e34-d891-4f81-b752-13a10245677f">


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR