### PR TITLE
ci: fix swiftformat and upgrade it to 0.54.6

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -70,13 +70,12 @@ jobs:
         with:
           path: /home/linuxbrew/.linuxbrew
           key: ${{ runner.os }}-linuxbrew
-      - name: Setup homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-      - name: Install swiftformat
+      - name: Install swiftformat 0.54.6
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/86f85aaa82beba49f8a5aabf3a22508c9249f188/Formula/s/swiftformat.rb
+          curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/4564fbc21a326c4eb349327ce327cbe983bf302a/Formula/s/swiftformat.rb
           echo 'brew "swiftformat.rb"' > Brewfile
           brew bundle
       - name: Save Cache
@@ -87,10 +86,12 @@ jobs:
           key: ${{ runner.os }}-linuxbrew
       - name: Formatter version
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           swiftformat --version
       - name: Run format
         if: ${{ success() || failure() }}
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           melos run format
       - name: Validate formatting
         if: ${{ success() || failure() }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,9 @@ _See also: [Flutter's code of conduct](https://flutter.io/design-principles/#cod
 - **Code Formatting:** [`swiftformat`](https://github.com/nicklockwood/SwiftFormat) (available via brew on macOS, on Windows install Swift toolchain and build SwiftFormat from git sources). 
 
 ### 1.1. Installing swiftformat
-The CI is locked to swiftformat 0.53 version which you can install with the command below:
+The CI is locked to swiftformat 0.54.6 version which you can install with the command below:
 ```bash
-curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/86f85aaa82beba49f8a5aabf3a22508c9249f188/Formula/s/swiftformat.rb
+curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/4564fbc21a326c4eb349327ce327cbe983bf302a/Formula/s/swiftformat.rb
 brew install swiftformat.rb
 ```
 

--- a/ios/Classes/Convert.swift
+++ b/ios/Classes/Convert.swift
@@ -196,7 +196,6 @@ enum Convert {
       return .left
     case .right:
       return .right
-
     @unknown default:
       return .none
     }


### PR DESCRIPTION
Fixes ci issues with swiftformat by start using already installed homebrew

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR