### PR TITLE
ci: upgrade ios simulator from iPhone 14 Pro to iPhone 16 Pro

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -117,7 +117,7 @@ jobs:
         working-directory: ${{ env.working_directory }}
         run: flutter build ios --config-only
       - name: "Run iOS native unit tests"
-        run: DEVICE='iPhone 14 Pro' melos run test:ios
+        run: DEVICE='iPhone 16 Pro' melos run test:ios
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/tool/test-ios.sh
+++ b/tool/test-ios.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -e
 
-DEVICE_NAME=${DEVICE:-'iPhone 14 Pro'} # Default to 'iPhone 14 Pro' if no argument is provided
+DEVICE_NAME=${DEVICE:-'iPhone 16 Pro'} # Default to 'iPhone 16 Pro' if no argument is provided
 
 # Navigate to the ios directory and run xcodebuild with the provided device name
 cd ios && xcodebuild test \


### PR DESCRIPTION
Upgrades simulator version for iOS native unit tests

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR