### PR TITLE
ci: add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,9 @@
 name: Publish to pub.dev
 
 on:
-  workflow_call: # called when release-please steps.release.outputs.release_created
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch: # manually trigger if previous runs failed
 
 concurrency:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,32 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# A workflow that publishes the library to CocoaPods
+name: Publish to pub.dev
+
 on:
-  push:
-    branches:
-      - main
+  workflow_call: # called when release-please steps.release.outputs.release_created
+  workflow_dispatch: # manually trigger if previous runs failed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: publishing
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
-
-name: release-please
-
+# Publish using the reusable workflow from dart-lang.
 jobs:
-  release-please:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: googleapis/release-please-action@v4
-        with:
-          token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
-          release-type: dart
-
   publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_ready }}
-    uses: ./.github/workflows/publish.yml
-    secrets: inherit
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,9 +35,3 @@ jobs:
         with:
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
           release-type: dart
-
-  publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_ready }}
-    uses: ./.github/workflows/publish.yml
-    secrets: inherit


### PR DESCRIPTION
Adds publish workflow to the project.
Publish new version of the package when new tag is pushed.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR