### PR TITLE
chore: pin release-please-action version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f
         with:
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
           release-type: dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.5.0](https://github.com/googlemaps/flutter-navigation-sdk/compare/v0.4.0...v0.5.0) (2025-02-10)
+## [0.5.0](https://github.com/googlemaps/flutter-navigation-sdk/compare/v0.4.0...0.5.0) (2025-02-10)
 
 
 ### Features


### PR DESCRIPTION
Pin release please action to commit that uses newer version of the release-please package (16.12.0)
https://github.com/googleapis/release-please-action/blob/7987652d64b4581673a76e33ad5e98e3dd56832f/package.json#L32
That have fix for include-v-in-tag option:
https://github.com/googleapis/release-please/blob/90058f543cd82858539fdc7d1b34eabd348edbee/CHANGELOG.md?plain=1#L78

Fix tag in changelog