### PR TITLE
chore: update release-please-action to version 4.1.4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f
+      - uses: googleapis/release-please-action@d1a8f221d7723166f48a584aebba00ef3f6febec
         with:
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
           release-type: dart


### PR DESCRIPTION
Updates release-please-action version to version 4.1.4
This change updates release-please npm package from 16.12.0 to 16.14.1 fixing issues with "include-v-in-tag" option (fixed in release please version 16.12.1)