### PR TITLE
chore: updates Navigation SDK for Android to 6.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,7 +79,7 @@ android {
     dependencies {
         implementation "androidx.car.app:app:1.4.0"
         implementation "androidx.car.app:app-projected:1.4.0"
-        implementation "com.google.android.libraries.navigation:navigation:6.0.2"
+        implementation "com.google.android.libraries.navigation:navigation:6.1.0"
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'io.mockk:mockk:1.13.8'
         testImplementation 'junit:junit:4.13.2'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -107,7 +107,7 @@ flutter {
 dependencies {
     implementation "androidx.car.app:app:1.4.0"
     implementation "androidx.car.app:app-projected:1.4.0"
-    implementation "com.google.android.libraries.navigation:navigation:6.0.2"
+    implementation "com.google.android.libraries.navigation:navigation:6.1.0"
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
     androidTestUtil "androidx.test:orchestrator:1.4.2"
 }


### PR DESCRIPTION
Updates Navigation SDK for Android version from 6.0.2 to 6.1.0

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/