### PR TITLE
fix: android unregisterListeners navigator check on app disposal

### DIFF
--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsNavigationSessionManager.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsNavigationSessionManager.kt
@@ -291,30 +291,32 @@ private constructor(private val navigationSessionEventApi: NavigationSessionEven
   }
 
   private fun unregisterListeners() {
-    val navigator = getNavigator()
-    if (remainingTimeOrDistanceChangedListener != null) {
-      navigator.removeRemainingTimeOrDistanceChangedListener(remainingTimeOrDistanceChangedListener)
-      remainingTimeOrDistanceChangedListener = null
-    }
-    if (arrivalListener != null) {
-      navigator.removeArrivalListener(arrivalListener)
-      arrivalListener = null
-    }
-    if (routeChangedListener != null) {
-      navigator.removeRouteChangedListener(routeChangedListener)
-      routeChangedListener = null
-    }
-    if (reroutingListener != null) {
-      navigator.removeReroutingListener(reroutingListener)
-      reroutingListener = null
-    }
-    if (trafficUpdatedListener != null) {
-      navigator.removeTrafficUpdatedListener(trafficUpdatedListener)
-      trafficUpdatedListener = null
-    }
-    if (speedingListener != null) {
-      navigator.setSpeedingListener(null)
-      speedingListener = null
+    if (isInitialized()) {
+      val navigator = getNavigator()
+      if (remainingTimeOrDistanceChangedListener != null) {
+        navigator.removeRemainingTimeOrDistanceChangedListener(remainingTimeOrDistanceChangedListener)
+        remainingTimeOrDistanceChangedListener = null
+      }
+      if (arrivalListener != null) {
+        navigator.removeArrivalListener(arrivalListener)
+        arrivalListener = null
+      }
+      if (routeChangedListener != null) {
+        navigator.removeRouteChangedListener(routeChangedListener)
+        routeChangedListener = null
+      }
+      if (reroutingListener != null) {
+        navigator.removeReroutingListener(reroutingListener)
+        reroutingListener = null
+      }
+      if (trafficUpdatedListener != null) {
+        navigator.removeTrafficUpdatedListener(trafficUpdatedListener)
+        trafficUpdatedListener = null
+      }
+      if (speedingListener != null) {
+        navigator.setSpeedingListener(null)
+        speedingListener = null
+      }
     }
     if (roadSnappedLocationListener != null) {
       disableRoadSnappedLocationUpdates()

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsNavigationSessionManager.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsNavigationSessionManager.kt
@@ -294,7 +294,9 @@ private constructor(private val navigationSessionEventApi: NavigationSessionEven
     if (isInitialized()) {
       val navigator = getNavigator()
       if (remainingTimeOrDistanceChangedListener != null) {
-        navigator.removeRemainingTimeOrDistanceChangedListener(remainingTimeOrDistanceChangedListener)
+        navigator.removeRemainingTimeOrDistanceChangedListener(
+          remainingTimeOrDistanceChangedListener
+        )
         remainingTimeOrDistanceChangedListener = null
       }
       if (arrivalListener != null) {

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/messages.g.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/messages.g.swift
@@ -1814,7 +1814,7 @@ protocol NavigationViewCreationApi {
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-class NavigationViewCreationApiSetup {
+enum NavigationViewCreationApiSetup {
   /// The codec used by NavigationViewCreationApi.
   static var codec: FlutterStandardMessageCodec { NavigationViewCreationApiCodec.shared }
   /// Sets up an instance of `NavigationViewCreationApi` to handle messages through the
@@ -2079,7 +2079,7 @@ protocol MapViewApi {
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-class MapViewApiSetup {
+enum MapViewApiSetup {
   /// The codec used by MapViewApi.
   static var codec: FlutterStandardMessageCodec { MapViewApiCodec.shared }
   /// Sets up an instance of `MapViewApi` to handle messages through the `binaryMessenger`.
@@ -4027,7 +4027,7 @@ protocol ImageRegistryApi {
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-class ImageRegistryApiSetup {
+enum ImageRegistryApiSetup {
   /// The codec used by ImageRegistryApi.
   static var codec: FlutterStandardMessageCodec { ImageRegistryApiCodec.shared }
   /// Sets up an instance of `ImageRegistryApi` to handle messages through the `binaryMessenger`.
@@ -4678,7 +4678,7 @@ protocol NavigationSessionApi {
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-class NavigationSessionApiSetup {
+enum NavigationSessionApiSetup {
   /// The codec used by NavigationSessionApi.
   static var codec: FlutterStandardMessageCodec { NavigationSessionApiCodec.shared }
   /// Sets up an instance of `NavigationSessionApi` to handle messages through the
@@ -5917,7 +5917,7 @@ protocol AutoMapViewApi {
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-class AutoMapViewApiSetup {
+enum AutoMapViewApiSetup {
   /// The codec used by AutoMapViewApi.
   static var codec: FlutterStandardMessageCodec { AutoMapViewApiCodec.shared }
   /// Sets up an instance of `AutoMapViewApi` to handle messages through the `binaryMessenger`.
@@ -7645,7 +7645,7 @@ protocol NavigationInspector {
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
-class NavigationInspectorSetup {
+enum NavigationInspectorSetup {
   /// The codec used by NavigationInspector.
   /// Sets up an instance of `NavigationInspector` to handle messages through the `binaryMessenger`.
   static func setUp(binaryMessenger: FlutterBinaryMessenger, api: NavigationInspector?) {


### PR DESCRIPTION
Fixes exception thrown when closing the app if navigator was not initialized.

Fixes #274
Fixes #200

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/