### PR TITLE
chore: remove instructions to add contribution to authors file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,8 +265,6 @@ Once you have received an LGTM (Looks Good To Me) from a project maintainer and 
 Before contributing, please ensure that you have completed the
 [Contributor License Agreement](https://cla.developers.google.com/clas).
 This can be done online and only takes a few moments.
-If you are submitting code for the first time, please add your (or your
-organization's) name and contact information to the [AUTHORS](AUTHORS) file.
 
 This project uses Google's `addlicense` [here](https://github.com/google/addlicense) tool to add the license header to all necessary files. Running `addlicense` is a required step before committing any new files.
 


### PR DESCRIPTION
Removes mention about `AUTHORS` file from `CONTRIBUTION.md` that was removed earlier at https://github.com/googlemaps/flutter-navigation-sdk/pull/127

Fixes #153

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/