### PR TITLE
ci: remove release-type from release-please-action config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,4 +34,3 @@ jobs:
       - uses: googleapis/release-please-action@d1a8f221d7723166f48a584aebba00ef3f6febec
         with:
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
-          release-type: dart

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
   "bump-minor-pre-major": true,
   "packages": {
     ".": {
-      "last-release-sha": "13e7f1c97dbe724ec2b86686a56489dd980b2f20",
       "package-name": "google_navigation_flutter",
       "changelog-path": "CHANGELOG.md"
     }


### PR DESCRIPTION
Removes release-type from release-please-action config to allow release please to use manifest config file.
