### PR TITLE
fix: onCameraMove, onCameraIdle, onCameraMoveStarted methods on GoogleMapsMapView widget

### DIFF
--- a/example/integration_test/shared.dart
+++ b/example/integration_test/shared.dart
@@ -292,31 +292,35 @@ Future<GoogleMapViewController> getMapViewControllerForTestMapType(
         onMyLocationButtonClicked: onMyLocationButtonClicked,
         onMyLocationClicked: onMyLocationClicked,
         onPolygonClicked: onPolygonClicked,
-        onPolylineClicked: onPolygonClicked,
+        onPolylineClicked: onPolylineClicked,
+        onCameraIdle: onCameraIdle,
       ); // Instantiate a regular map.
       break;
 
     /// Set up navigation map.
     case TestMapType.navigationView:
-      viewController = await startNavigationWithoutDestination($,
-          initializeNavigation: initializeNavigation,
-          simulateLocation: simulateLocation,
-          onMarkerClicked: onMarkerClicked,
-          onCircleClicked: onCircleClicked,
-          onMapClicked: onMapClicked,
-          onMapLongClicked: onMapLongClicked,
-          onMarkerDrag: onMarkerDrag,
-          onMarkerDragEnd: onMarkerDragEnd,
-          onMarkerDragStart: onMarkerDragStart,
-          onMarkerInfoWindowClicked: onMarkerInfoWindowClicked,
-          onMarkerInfoWindowClosed: onMarkerInfoWindowClosed,
-          onMarkerInfoWindowLongClicked: onMarkerInfoWindowLongClicked,
-          onMyLocationButtonClicked: onMyLocationButtonClicked,
-          onMyLocationClicked: onMyLocationClicked,
-          onPolygonClicked: onPolygonClicked,
-          onPolylineClicked: onPolygonClicked,
-          onRecenterButtonClicked:
-              onRecenterButtonClicked); // Instantiate a navigation map.
+      viewController = await startNavigationWithoutDestination(
+        $,
+        initializeNavigation: initializeNavigation,
+        simulateLocation: simulateLocation,
+        onMarkerClicked: onMarkerClicked,
+        onCircleClicked: onCircleClicked,
+        onMapClicked: onMapClicked,
+        onMapLongClicked: onMapLongClicked,
+        onMarkerDrag: onMarkerDrag,
+        onMarkerDragEnd: onMarkerDragEnd,
+        onMarkerDragStart: onMarkerDragStart,
+        onMarkerInfoWindowClicked: onMarkerInfoWindowClicked,
+        onMarkerInfoWindowClosed: onMarkerInfoWindowClosed,
+        onMarkerInfoWindowLongClicked: onMarkerInfoWindowLongClicked,
+        onMyLocationButtonClicked: onMyLocationButtonClicked,
+        onMyLocationClicked: onMyLocationClicked,
+        onNavigationUIEnabledChanged: onNavigationUIEnabledChanged,
+        onPolygonClicked: onPolygonClicked,
+        onPolylineClicked: onPolylineClicked,
+        onRecenterButtonClicked: onRecenterButtonClicked,
+        onCameraIdle: onCameraIdle,
+      ); // Instantiate a navigation map.
       break;
   }
   return viewController;
@@ -377,8 +381,9 @@ Future<GoogleNavigationViewController> startNavigationWithoutDestination(
       onMyLocationClicked: onMyLocationClicked,
       onNavigationUIEnabledChanged: onNavigationUIEnabledChanged,
       onPolygonClicked: onPolygonClicked,
-      onPolylineClicked: onPolygonClicked,
+      onPolylineClicked: onPolylineClicked,
       onRecenterButtonClicked: onRecenterButtonClicked,
+      onCameraIdle: onCameraIdle,
     ),
   );
 
@@ -451,8 +456,9 @@ Future<GoogleMapViewController> startMapView(
       onMyLocationButtonClicked: onMyLocationButtonClicked,
       onMyLocationClicked: onMyLocationClicked,
       onPolygonClicked: onPolygonClicked,
-      onPolylineClicked: onPolygonClicked,
+      onPolylineClicked: onPolylineClicked,
       onRecenterButtonClicked: onRecenterButtonClicked,
+      onCameraIdle: onCameraIdle,
     ),
   );
 

--- a/example/lib/pages/camera.dart
+++ b/example/lib/pages/camera.dart
@@ -48,7 +48,10 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
     calculateFocusCenter();
     _minZoomLevel = await _navigationViewController.getMinZoomPreference();
     _maxZoomLevel = await _navigationViewController.getMaxZoomPreference();
-    setState(() {});
+
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   Future<void> _startNavigation() async {
@@ -78,6 +81,10 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
       displayOptions: NavigationDisplayOptions(showDestinationMarkers: false),
     );
 
+    if (!mounted) {
+      return;
+    }
+
     setState(() {});
     final NavigationRouteStatus status =
         await GoogleMapsNavigator.setDestinations(msg);
@@ -88,9 +95,11 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
       await _navigationViewController
           .followMyLocation(CameraPerspective.tilted);
 
-      setState(() {
-        _navigationRunning = true;
-      });
+      if (mounted) {
+        setState(() {
+          _navigationRunning = true;
+        });
+      }
     } else {
       showMessage('Starting navigation failed.');
     }
@@ -100,9 +109,11 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
     if (_navigationRunning) {
       await GoogleMapsNavigator.cleanup();
 
-      setState(() {
-        _navigationRunning = false;
-      });
+      if (mounted) {
+        setState(() {
+          _navigationRunning = false;
+        });
+      }
     }
   }
 
@@ -150,6 +161,9 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
           ]));
 
   void _onCameraMoveStarted(CameraPosition position, bool gesture) {
+    if (!mounted) {
+      return;
+    }
     if (_showCameraUpdates) {
       showMessage(gesture
           ? 'Camera move started by gesture'
@@ -158,6 +172,9 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
   }
 
   void _onCameraMove(CameraPosition position) {
+    if (!mounted) {
+      return;
+    }
     final String cameraState =
         _isFollowingLocation ? 'Camera following' : 'Camera moving';
     final String positionStr =
@@ -168,6 +185,9 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
   }
 
   void _onCameraIdle(CameraPosition position) {
+    if (!mounted) {
+      return;
+    }
     setState(() {
       _latestCameraUpdate =
           'Camera idle\nPosition: ${position.target.latitude.toStringAsFixed(2)}, ${position.target.longitude.toStringAsFixed(2)}';
@@ -176,6 +196,9 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
 
   // Android only.
   void _onCameraStartedFollowingLocation(CameraPosition position) {
+    if (!mounted) {
+      return;
+    }
     setState(() {
       _isFollowingLocation = true;
     });
@@ -183,12 +206,18 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
 
   // Android only.
   void _onCameraStoppedFollowingLocation(CameraPosition position) {
+    if (!mounted) {
+      return;
+    }
     setState(() {
       _isFollowingLocation = false;
     });
   }
 
   void showMessage(String message) {
+    if (!mounted) {
+      return;
+    }
     hideMessage();
     if (isOverlayVisible) {
       showOverlaySnackBar(message);
@@ -202,7 +231,10 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
     ScaffoldMessenger.of(context).removeCurrentSnackBar();
   }
 
-  void showAnimationFinishedMessage(bool success) {
+  void _showAnimationFinishedMessage(bool success) {
+    if (!mounted) {
+      return;
+    }
     if (_displayAnimationFinished) {
       showMessage(success ? 'Animation finished' : 'Animation canceled');
     }
@@ -322,7 +354,7 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
                           ? Duration(milliseconds: _animationDuration!)
                           : null,
                       onFinished: (bool success) =>
-                          showAnimationFinishedMessage(success));
+                          _showAnimationFinishedMessage(success));
                 } else {
                   _navigationViewController.moveCamera(cameraUpdate);
                 }
@@ -339,7 +371,7 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
                           ? Duration(milliseconds: _animationDuration!)
                           : null,
                       onFinished: (bool success) =>
-                          showAnimationFinishedMessage(success));
+                          _showAnimationFinishedMessage(success));
                 } else {
                   _navigationViewController.moveCamera(cameraUpdate);
                 }
@@ -363,7 +395,7 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
                           ? Duration(milliseconds: _animationDuration!)
                           : null,
                       onFinished: (bool success) =>
-                          showAnimationFinishedMessage(success));
+                          _showAnimationFinishedMessage(success));
                 } else {
                   _navigationViewController.moveCamera(cameraUpdate);
                 }
@@ -387,7 +419,7 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
                           ? Duration(milliseconds: _animationDuration!)
                           : null,
                       onFinished: (bool success) =>
-                          showAnimationFinishedMessage(success));
+                          _showAnimationFinishedMessage(success));
                 } else {
                   _navigationViewController.moveCamera(cameraUpdate);
                 }
@@ -407,7 +439,7 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
                       ? Duration(milliseconds: _animationDuration!)
                       : null,
                   onFinished: (bool success) =>
-                      showAnimationFinishedMessage(success));
+                      _showAnimationFinishedMessage(success));
             } else {
               _navigationViewController.moveCamera(cameraUpdate);
             }
@@ -428,7 +460,7 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
                           ? Duration(milliseconds: _animationDuration!)
                           : null,
                       onFinished: (bool success) =>
-                          showAnimationFinishedMessage(success));
+                          _showAnimationFinishedMessage(success));
                 } else {
                   _navigationViewController.moveCamera(cameraUpdate);
                 }
@@ -447,7 +479,7 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
                           ? Duration(milliseconds: _animationDuration!)
                           : null,
                       onFinished: (bool success) =>
-                          showAnimationFinishedMessage(success));
+                          _showAnimationFinishedMessage(success));
                 } else {
                   _navigationViewController.moveCamera(cameraUpdate);
                 }
@@ -470,7 +502,7 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
                           ? Duration(milliseconds: _animationDuration!)
                           : null,
                       onFinished: (bool success) =>
-                          showAnimationFinishedMessage(success));
+                          _showAnimationFinishedMessage(success));
                 } else {
                   _navigationViewController.moveCamera(cameraUpdate);
                 }
@@ -487,7 +519,7 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
                           ? Duration(milliseconds: _animationDuration!)
                           : null,
                       onFinished: (bool success) =>
-                          showAnimationFinishedMessage(success));
+                          _showAnimationFinishedMessage(success));
                 } else {
                   _navigationViewController.moveCamera(cameraUpdate);
                 }
@@ -505,7 +537,7 @@ class _CameraPageState extends ExamplePageState<CameraPage> {
                           ? Duration(milliseconds: _animationDuration!)
                           : null,
                       onFinished: (bool success) =>
-                          showAnimationFinishedMessage(success));
+                          _showAnimationFinishedMessage(success));
                 } else {
                   _navigationViewController.moveCamera(cameraUpdate);
                 }

--- a/lib/src/google_maps_map_view.dart
+++ b/lib/src/google_maps_map_view.dart
@@ -355,6 +355,31 @@ abstract class MapViewState<T extends GoogleMapsBaseMapView> extends State<T> {
         widget.onCircleClicked?.call(event.circleId);
       });
     });
+
+    if (widget.onCameraMoveStarted != null ||
+        widget.onCameraMove != null ||
+        widget.onCameraIdle != null) {
+      GoogleMapsNavigationPlatform.instance.viewAPI
+          .registerOnCameraChangedListener(viewId: viewId);
+    }
+    GoogleMapsNavigationPlatform.instance.viewAPI
+        .getCameraChangedEventStream(viewId: viewId)
+        .listen((CameraChangedEvent event) {
+      switch (event.eventType) {
+        case CameraEventType.moveStartedByApi:
+          widget.onCameraMoveStarted?.call(event.position, false);
+        case CameraEventType.moveStartedByGesture:
+          widget.onCameraMoveStarted?.call(event.position, true);
+        case CameraEventType.onCameraMove:
+          widget.onCameraMove?.call(event.position);
+        case CameraEventType.onCameraIdle:
+          widget.onCameraIdle?.call(event.position);
+        case CameraEventType.onCameraStartedFollowingLocation:
+          widget.onCameraStartedFollowingLocation?.call(event.position);
+        case CameraEventType.onCameraStoppedFollowingLocation:
+          widget.onCameraStoppedFollowingLocation?.call(event.position);
+      }
+    });
   }
 }
 

--- a/lib/src/google_maps_navigation_view.dart
+++ b/lib/src/google_maps_navigation_view.dart
@@ -181,30 +181,5 @@ class GoogleMapsNavigationViewState
           .getMyLocationButtonClickedEventStream(viewId: viewId)
           .listen(widget.onMyLocationButtonClicked);
     }
-    if (widget.onCameraMoveStarted != null ||
-        widget.onCameraMove != null ||
-        widget.onCameraIdle != null) {
-      GoogleMapsNavigationPlatform.instance.viewAPI
-          .registerOnCameraChangedListener(viewId: viewId);
-    }
-
-    GoogleMapsNavigationPlatform.instance.viewAPI
-        .getCameraChangedEventStream(viewId: viewId)
-        .listen((CameraChangedEvent event) {
-      switch (event.eventType) {
-        case CameraEventType.moveStartedByApi:
-          widget.onCameraMoveStarted?.call(event.position, false);
-        case CameraEventType.moveStartedByGesture:
-          widget.onCameraMoveStarted?.call(event.position, true);
-        case CameraEventType.onCameraMove:
-          widget.onCameraMove?.call(event.position);
-        case CameraEventType.onCameraIdle:
-          widget.onCameraIdle?.call(event.position);
-        case CameraEventType.onCameraStartedFollowingLocation:
-          widget.onCameraStartedFollowingLocation?.call(event.position);
-        case CameraEventType.onCameraStoppedFollowingLocation:
-          widget.onCameraStoppedFollowingLocation?.call(event.position);
-      }
-    });
   }
 }


### PR DESCRIPTION
Fixes onCameraMove, onCameraIdle, onCameraMoveStarted methods on GoogleMapsMapView widget.

Fixes #287 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/