### PR TITLE
chore: add changelog header to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## [0.5.1](https://github.com/googlemaps/flutter-navigation-sdk/compare/0.5.0...0.5.1) (2025-02-27)
 
 


### PR DESCRIPTION
Adds missing changlog header to CHANGELOG.md file.
Lack of this header most likely caused visible issues with release-please automatic CHANGELOG.md modification