### PR TITLE
fix: update minimum supported SDK version to Flutter 3.27/Dart 3.6.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,8 @@ issue_tracker: https://github.com/googlemaps/flutter-navigation-sdk/issues
 version: 0.5.1
 
 environment:
-  sdk: ^3.4.0
-  flutter: ">=3.22.1"
+  sdk: ^3.6.0
+  flutter: ">=3.27.0"
 
 dependencies:
   collection: ^1.17.2


### PR DESCRIPTION
Release [0.5.0](https://github.com/googlemaps/flutter-navigation-sdk/releases/tag/0.5.0) introduced bug as it implemented new Color API introduced in Flutter 3.27 without updating minimun supported SDK version to Flutter 3.27.
This PR patches this.

Fixes https://github.com/googlemaps/flutter-navigation-sdk/issues/296

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/