### PR TITLE
fix: initialize view listeners on platform view creation

### DIFF
--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoViewMessageHandler.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoViewMessageHandler.kt
@@ -378,8 +378,8 @@ class GoogleMapsAutoViewMessageHandler(private val viewRegistry: GoogleMapsViewR
     getView().clearCircles()
   }
 
-  override fun registerOnCameraChangedListener() {
-    getView().registerOnCameraChangedListener()
+  override fun enableOnCameraChangedEvents() {
+    getView().enableOnCameraChangedEvents()
   }
 
   override fun isAutoScreenAvailable(): Boolean {

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsBaseMapView.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsBaseMapView.kt
@@ -59,7 +59,7 @@ abstract class GoogleMapsBaseMapView(
 
   // Nullable variable to hold the callback function
   private var _mapReadyCallback: ((Result<Unit>) -> Unit)? = null
-  private var _loadedCallbackPending = false
+  private var _pendingCameraEventsListererSetup = false
 
   /// Default values for UI features.
   private var _consumeMyLocationButtonClickEventsEnabled: Boolean = false
@@ -212,6 +212,10 @@ abstract class GoogleMapsBaseMapView(
           }
         }
       )
+
+    if (_pendingCameraEventsListererSetup) {
+      setOnCameraChangedListeners()
+    }
   }
 
   // Installs a custom invalidator for the map view.
@@ -910,7 +914,17 @@ abstract class GoogleMapsBaseMapView(
     _circles.clear()
   }
 
-  fun registerOnCameraChangedListener() {
+  fun enableOnCameraChangedEvents() {
+    // If map is already initialized, set the listeners.
+    // Otherwise, the listeners will be set in the initListeners method.
+    if (_map != null) {
+      setOnCameraChangedListeners()
+    } else {
+      _pendingCameraEventsListererSetup = true
+    }
+  }
+
+  fun setOnCameraChangedListeners() {
     getMap().setOnCameraMoveStartedListener { reason ->
       val event =
         when (reason) {
@@ -943,6 +957,7 @@ abstract class GoogleMapsBaseMapView(
         position,
       ) {}
     }
+    _pendingCameraEventsListererSetup = false
   }
 
   fun setPadding(padding: MapPaddingDto) {

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsBaseMapView.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsBaseMapView.kt
@@ -59,7 +59,7 @@ abstract class GoogleMapsBaseMapView(
 
   // Nullable variable to hold the callback function
   private var _mapReadyCallback: ((Result<Unit>) -> Unit)? = null
-  private var _pendingCameraEventsListererSetup = false
+  private var _pendingCameraEventsListenerSetup = false
 
   /// Default values for UI features.
   private var _consumeMyLocationButtonClickEventsEnabled: Boolean = false
@@ -213,7 +213,7 @@ abstract class GoogleMapsBaseMapView(
         }
       )
 
-    if (_pendingCameraEventsListererSetup) {
+    if (_pendingCameraEventsListenerSetup) {
       setOnCameraChangedListeners()
     }
   }
@@ -920,7 +920,7 @@ abstract class GoogleMapsBaseMapView(
     if (_map != null) {
       setOnCameraChangedListeners()
     } else {
-      _pendingCameraEventsListererSetup = true
+      _pendingCameraEventsListenerSetup = true
     }
   }
 
@@ -957,7 +957,7 @@ abstract class GoogleMapsBaseMapView(
         position,
       ) {}
     }
-    _pendingCameraEventsListererSetup = false
+    _pendingCameraEventsListenerSetup = false
   }
 
   fun setPadding(padding: MapPaddingDto) {

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsViewMessageHandler.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsViewMessageHandler.kt
@@ -488,8 +488,8 @@ class GoogleMapsViewMessageHandler(private val viewRegistry: GoogleMapsViewRegis
     getView(viewId.toInt()).clearCircles()
   }
 
-  override fun registerOnCameraChangedListener(viewId: Long) {
-    getView(viewId.toInt()).registerOnCameraChangedListener()
+  override fun enableOnCameraChangedEvents(viewId: Long) {
+    getView(viewId.toInt()).enableOnCameraChangedEvents()
   }
 
   override fun setPadding(viewId: Long, padding: MapPaddingDto) {

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/ImageRegistry.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/ImageRegistry.kt
@@ -27,6 +27,8 @@ class ImageRegistry {
 
   private var isMapViewInitialized = false
 
+  // BitmapDescriptor cannot be created if map view is not initialized yet.
+  // When map view is initialized, all queued bitmaps are processed and added to the registry.
   fun mapViewInitializationComplete() {
     isMapViewInitialized = true
     bitmapQueue.forEach {
@@ -47,7 +49,7 @@ class ImageRegistry {
     val bitmap = createBitmap(bytes, imagePixelRatio, density, width, height)
 
     if (!isMapViewInitialized) {
-      // BitmapDescriptor cannot me created if map view is not initialized yet.
+      // BitmapDescriptor cannot be created if map view is not initialized yet.
       // Add to queue to make it later.
       bitmapQueue.add(QueuedBitmap(imageId, bitmap, imagePixelRatio, width, height))
     } else {

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/messages.g.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/messages.g.kt
@@ -2230,7 +2230,7 @@ interface MapViewApi {
 
   fun clearCircles(viewId: Long)
 
-  fun registerOnCameraChangedListener(viewId: Long)
+  fun enableOnCameraChangedEvents(viewId: Long)
 
   fun setPadding(viewId: Long, padding: MapPaddingDto)
 
@@ -4522,7 +4522,7 @@ interface MapViewApi {
         val channel =
           BasicMessageChannel<Any?>(
             binaryMessenger,
-            "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.registerOnCameraChangedListener",
+            "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.enableOnCameraChangedEvents",
             codec,
           )
         if (api != null) {
@@ -4531,7 +4531,7 @@ interface MapViewApi {
             val viewIdArg = args[0].let { if (it is Int) it.toLong() else it as Long }
             var wrapped: List<Any?>
             try {
-              api.registerOnCameraChangedListener(viewIdArg)
+              api.enableOnCameraChangedEvents(viewIdArg)
               wrapped = listOf<Any?>(null)
             } catch (exception: Throwable) {
               wrapped = wrapError(exception)
@@ -6630,7 +6630,7 @@ interface AutoMapViewApi {
 
   fun clearCircles()
 
-  fun registerOnCameraChangedListener()
+  fun enableOnCameraChangedEvents()
 
   fun isAutoScreenAvailable(): Boolean
 
@@ -8297,14 +8297,14 @@ interface AutoMapViewApi {
         val channel =
           BasicMessageChannel<Any?>(
             binaryMessenger,
-            "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.registerOnCameraChangedListener",
+            "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.enableOnCameraChangedEvents",
             codec,
           )
         if (api != null) {
           channel.setMessageHandler { _, reply ->
             var wrapped: List<Any?>
             try {
-              api.registerOnCameraChangedListener()
+              api.enableOnCameraChangedEvents()
               wrapped = listOf<Any?>(null)
             } catch (exception: Throwable) {
               wrapped = wrapError(exception)

--- a/example/lib/pages/navigation.dart
+++ b/example/lib/pages/navigation.dart
@@ -1405,12 +1405,14 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
                       ElevatedButton(
                         onPressed: _pauseSimulation,
                         child: const Text('Pause simulation'),
-                      ),
-                    if (_simulationState == SimulationState.paused)
+                      )
+                    else if (_simulationState == SimulationState.paused)
                       ElevatedButton(
                         onPressed: _resumeSimulation,
                         child: const Text('Resume simulation'),
-                      ),
+                      )
+                    else
+                      Text(_simulationState.description),
                   ],
                 ),
                 const SizedBox(height: 10)
@@ -1768,6 +1770,24 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
     } else {
       final SnackBar snackBar = SnackBar(content: Text(message));
       ScaffoldMessenger.of(context).showSnackBar(snackBar);
+    }
+  }
+}
+
+/// Returns a human-readable description of the [SimulationState].
+extension SimulationStateDescription on SimulationState {
+  String get description {
+    switch (this) {
+      case SimulationState.unknown:
+        return 'Unknown simulation state';
+      case SimulationState.running:
+        return 'Running';
+      case SimulationState.runningOutdated:
+        return 'Running with outdated route';
+      case SimulationState.paused:
+        return 'Paused';
+      case SimulationState.notRunning:
+        return 'Not running';
     }
   }
 }

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsAutoViewMessageHandler.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsAutoViewMessageHandler.swift
@@ -464,8 +464,8 @@ class GoogleMapsAutoViewMessageHandler: AutoMapViewApi {
     try getView().setMaxZoomPreference(maxZoomPreference: Float(maxZoomPreference))
   }
 
-  func registerOnCameraChangedListener() throws {
-    try getView().registerOnCameraChangedListener()
+  func enableOnCameraChangedEvents() throws {
+    try getView().enableOnCameraChangedEvents()
   }
 
   func isAutoScreenAvailable() throws -> Bool {

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationView.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationView.swift
@@ -868,7 +868,7 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
     _consumeMyLocationButtonClickEventsEnabled
   }
 
-  func registerOnCameraChangedListener() {
+  func enableOnCameraChangedEvents() {
     // Camera listeners cannot be controlled at runtime, so use this
     // boolean to control if camera changes are sent over the event channel.
     _listenCameraChanges = true

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewMessageHandler.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewMessageHandler.swift
@@ -548,8 +548,8 @@ class GoogleMapsNavigationViewMessageHandler: MapViewApi {
     try getView(viewId).setMaxZoomPreference(maxZoomPreference: Float(maxZoomPreference))
   }
 
-  func registerOnCameraChangedListener(viewId: Int64) throws {
-    try getView(viewId).registerOnCameraChangedListener()
+  func enableOnCameraChangedEvents(viewId: Int64) throws {
+    try getView(viewId).enableOnCameraChangedEvents()
   }
 
   func setPadding(viewId: Int64, padding: MapPaddingDto) throws {

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/messages.g.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/messages.g.swift
@@ -2042,7 +2042,7 @@ protocol MapViewApi {
   func updateCircles(viewId: Int64, circles: [CircleDto]) throws -> [CircleDto]
   func removeCircles(viewId: Int64, circles: [CircleDto]) throws
   func clearCircles(viewId: Int64) throws
-  func registerOnCameraChangedListener(viewId: Int64) throws
+  func enableOnCameraChangedEvents(viewId: Int64) throws
   func setPadding(viewId: Int64, padding: MapPaddingDto) throws
   func getPadding(viewId: Int64) throws -> MapPaddingDto
 }
@@ -3761,23 +3761,22 @@ class MapViewApiSetup {
     } else {
       clearCirclesChannel.setMessageHandler(nil)
     }
-    let registerOnCameraChangedListenerChannel = FlutterBasicMessageChannel(
-      name:
-        "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.registerOnCameraChangedListener",
+    let enableOnCameraChangedEventsChannel = FlutterBasicMessageChannel(
+      name: "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.enableOnCameraChangedEvents",
       binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
-      registerOnCameraChangedListenerChannel.setMessageHandler { message, reply in
+      enableOnCameraChangedEventsChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let viewIdArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
         do {
-          try api.registerOnCameraChangedListener(viewId: viewIdArg)
+          try api.enableOnCameraChangedEvents(viewId: viewIdArg)
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))
         }
       }
     } else {
-      registerOnCameraChangedListenerChannel.setMessageHandler(nil)
+      enableOnCameraChangedEventsChannel.setMessageHandler(nil)
     }
     let setPaddingChannel = FlutterBasicMessageChannel(
       name: "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setPadding",
@@ -5630,7 +5629,7 @@ protocol AutoMapViewApi {
   func updateCircles(circles: [CircleDto]) throws -> [CircleDto]
   func removeCircles(circles: [CircleDto]) throws
   func clearCircles() throws
-  func registerOnCameraChangedListener() throws
+  func enableOnCameraChangedEvents() throws
   func isAutoScreenAvailable() throws -> Bool
   func setPadding(padding: MapPaddingDto) throws
   func getPadding() throws -> MapPaddingDto
@@ -6855,21 +6854,21 @@ class AutoMapViewApiSetup {
     } else {
       clearCirclesChannel.setMessageHandler(nil)
     }
-    let registerOnCameraChangedListenerChannel = FlutterBasicMessageChannel(
+    let enableOnCameraChangedEventsChannel = FlutterBasicMessageChannel(
       name:
-        "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.registerOnCameraChangedListener",
+        "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.enableOnCameraChangedEvents",
       binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
-      registerOnCameraChangedListenerChannel.setMessageHandler { _, reply in
+      enableOnCameraChangedEventsChannel.setMessageHandler { _, reply in
         do {
-          try api.registerOnCameraChangedListener()
+          try api.enableOnCameraChangedEvents()
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))
         }
       }
     } else {
-      registerOnCameraChangedListenerChannel.setMessageHandler(nil)
+      enableOnCameraChangedEventsChannel.setMessageHandler(nil)
     }
     let isAutoScreenAvailableChannel = FlutterBasicMessageChannel(
       name: "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isAutoScreenAvailable",

--- a/lib/src/google_maps_map_view.dart
+++ b/lib/src/google_maps_map_view.dart
@@ -360,7 +360,7 @@ abstract class MapViewState<T extends GoogleMapsBaseMapView> extends State<T> {
         widget.onCameraMove != null ||
         widget.onCameraIdle != null) {
       GoogleMapsNavigationPlatform.instance.viewAPI
-          .registerOnCameraChangedListener(viewId: viewId);
+          .enableOnCameraChangedEvents(viewId: viewId);
     }
     GoogleMapsNavigationPlatform.instance.viewAPI
         .getCameraChangedEventStream(viewId: viewId)
@@ -412,13 +412,17 @@ class GoogleMapsMapViewState extends MapViewState<GoogleMapsMapView> {
             padding: widget.initialPadding,
           ),
         ),
-        onMapReady: _onPlatformViewCreated);
+        onPlatformViewCreated: _onPlatformViewCreated,
+        onMapReady: _onMapReady);
   }
 
-  /// Callback method when platform view is created.
+  /// Callback method for platform view is created event.
   void _onPlatformViewCreated(int viewId) {
     initMapViewListeners(viewId);
+  }
 
+  /// Callback method for map ready event.
+  void _onMapReady(int viewId) {
     final GoogleMapViewController viewController =
         GoogleMapViewController(viewId);
     widget.onViewCreated(viewController);

--- a/lib/src/google_maps_navigation_view.dart
+++ b/lib/src/google_maps_navigation_view.dart
@@ -146,13 +146,18 @@ class GoogleMapsNavigationViewState
             navigationViewOptions: NavigationViewOptions(
                 navigationUIEnabledPreference:
                     widget.initialNavigationUIEnabledPreference)),
-        onMapReady: _onPlatformViewCreated);
+        onPlatformViewCreated: _onPlatformViewCreated,
+        onMapReady: _onMapReady);
   }
 
-  /// Callback method when platform view is created.
+  /// Callback method for platform view is created event.
   void _onPlatformViewCreated(int viewId) {
     initMapViewListeners(viewId);
     _initNavigationViewListeners(viewId);
+  }
+
+  /// Callback method for map ready event.
+  void _onMapReady(int viewId) {
     final GoogleNavigationViewController viewController =
         GoogleNavigationViewController(viewId);
     widget.onViewCreated(viewController);

--- a/lib/src/google_navigation_flutter_android.dart
+++ b/lib/src/google_navigation_flutter_android.dart
@@ -50,26 +50,31 @@ class GoogleMapsNavigationAndroid extends GoogleMapsNavigationPlatform {
   @override
   Widget buildMapView(
       {required MapViewInitializationOptions initializationOptions,
+      required PlatformViewCreatedCallback onPlatformViewCreated,
       required MapReadyCallback onMapReady}) {
     return _buildView(
         mapViewType: MapViewType.map,
         initializationOptions: initializationOptions,
+        onPlatformViewCreated: onPlatformViewCreated,
         onMapReady: onMapReady);
   }
 
   @override
   Widget buildNavigationView(
       {required MapViewInitializationOptions initializationOptions,
+      required PlatformViewCreatedCallback onPlatformViewCreated,
       required MapReadyCallback onMapReady}) {
     return _buildView(
         mapViewType: MapViewType.navigation,
         initializationOptions: initializationOptions,
+        onPlatformViewCreated: onPlatformViewCreated,
         onMapReady: onMapReady);
   }
 
   Widget _buildView(
       {required MapViewType mapViewType,
       required MapViewInitializationOptions initializationOptions,
+      required PlatformViewCreatedCallback onPlatformViewCreated,
       required MapReadyCallback onMapReady}) {
     // Initialize method channel for view communication if needed.
     viewAPI.ensureViewAPISetUp();
@@ -87,6 +92,8 @@ class GoogleMapsNavigationAndroid extends GoogleMapsNavigationPlatform {
     return AndroidView(
       viewType: viewType,
       onPlatformViewCreated: (int viewId) async {
+        onPlatformViewCreated(viewId);
+
         // On Android the map is initialized asyncronously.
         // Wait map to be ready before calling [onMapReady] callback
         await viewAPI.awaitMapReady(viewId: viewId);

--- a/lib/src/google_navigation_flutter_ios.dart
+++ b/lib/src/google_navigation_flutter_ios.dart
@@ -50,26 +50,31 @@ class GoogleMapsNavigationIOS extends GoogleMapsNavigationPlatform {
   @override
   Widget buildMapView(
       {required MapViewInitializationOptions initializationOptions,
+      required PlatformViewCreatedCallback onPlatformViewCreated,
       required MapReadyCallback onMapReady}) {
     return _buildView(
         mapViewType: MapViewType.map,
         initializationOptions: initializationOptions,
+        onPlatformViewCreated: onPlatformViewCreated,
         onMapReady: onMapReady);
   }
 
   @override
   Widget buildNavigationView(
       {required MapViewInitializationOptions initializationOptions,
+      required PlatformViewCreatedCallback onPlatformViewCreated,
       required MapReadyCallback onMapReady}) {
     return _buildView(
         mapViewType: MapViewType.navigation,
         initializationOptions: initializationOptions,
+        onPlatformViewCreated: onPlatformViewCreated,
         onMapReady: onMapReady);
   }
 
   Widget _buildView(
       {required MapViewType mapViewType,
       required MapViewInitializationOptions initializationOptions,
+      required PlatformViewCreatedCallback onPlatformViewCreated,
       required MapReadyCallback onMapReady}) {
     // Initialize method channel for view communication if needed.
     viewAPI.ensureViewAPISetUp();
@@ -89,6 +94,8 @@ class GoogleMapsNavigationIOS extends GoogleMapsNavigationPlatform {
       creationParams: creationParams.encode(),
       creationParamsCodec: const StandardMessageCodec(),
       onPlatformViewCreated: (int viewId) async {
+        onPlatformViewCreated(viewId);
+
         // Wait map to be ready before calling [onMapReady] callback
         await viewAPI.awaitMapReady(viewId: viewId);
         onMapReady(viewId);

--- a/lib/src/google_navigation_flutter_platform_interface.dart
+++ b/lib/src/google_navigation_flutter_platform_interface.dart
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:google_navigation_flutter/src/method_channel/method_channel.dart';
@@ -80,6 +81,7 @@ abstract class GoogleMapsNavigationPlatform extends PlatformInterface {
   /// and is ready for interaction.
   Widget buildMapView(
       {required MapViewInitializationOptions initializationOptions,
+      required PlatformViewCreatedCallback onPlatformViewCreated,
       required MapReadyCallback onMapReady});
 
   /// Builds and returns a navigation view.
@@ -91,6 +93,7 @@ abstract class GoogleMapsNavigationPlatform extends PlatformInterface {
   /// and is ready for interaction.
   Widget buildNavigationView(
       {required MapViewInitializationOptions initializationOptions,
+      required PlatformViewCreatedCallback onPlatformViewCreated,
       required MapReadyCallback onMapReady});
 
   /// Populates [GoogleNavigationInspectorPlatform.instance] to allow

--- a/lib/src/method_channel/auto_view_api.dart
+++ b/lib/src/method_channel/auto_view_api.dart
@@ -732,8 +732,8 @@ class AutoMapViewAPIImpl {
   }
 
   /// Register camera changed listeners.
-  Future<void> registerOnCameraChangedListener() {
-    return _viewApi.registerOnCameraChangedListener();
+  Future<void> enableOnCameraChangedEvents() {
+    return _viewApi.enableOnCameraChangedEvents();
   }
 
   Future<void> setPadding({required EdgeInsets padding}) {

--- a/lib/src/method_channel/map_view_api.dart
+++ b/lib/src/method_channel/map_view_api.dart
@@ -961,8 +961,8 @@ class MapViewAPIImpl {
   }
 
   /// Register camera changed listeners.
-  Future<void> registerOnCameraChangedListener({required int viewId}) {
-    return _viewApi.registerOnCameraChangedListener(viewId);
+  Future<void> enableOnCameraChangedEvents({required int viewId}) {
+    return _viewApi.enableOnCameraChangedEvents(viewId);
   }
 
   Future<void> setPadding({required int viewId, required EdgeInsets padding}) {

--- a/lib/src/method_channel/messages.g.dart
+++ b/lib/src/method_channel/messages.g.dart
@@ -4675,9 +4675,9 @@ class MapViewApi {
     }
   }
 
-  Future<void> registerOnCameraChangedListener(int viewId) async {
+  Future<void> enableOnCameraChangedEvents(int viewId) async {
     const String __pigeon_channelName =
-        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.registerOnCameraChangedListener';
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.enableOnCameraChangedEvents';
     final BasicMessageChannel<Object?> __pigeon_channel =
         BasicMessageChannel<Object?>(
       __pigeon_channelName,
@@ -8752,9 +8752,9 @@ class AutoMapViewApi {
     }
   }
 
-  Future<void> registerOnCameraChangedListener() async {
+  Future<void> enableOnCameraChangedEvents() async {
     const String __pigeon_channelName =
-        'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.registerOnCameraChangedListener';
+        'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.enableOnCameraChangedEvents';
     final BasicMessageChannel<Object?> __pigeon_channel =
         BasicMessageChannel<Object?>(
       __pigeon_channelName,

--- a/pigeons/messages.dart
+++ b/pigeons/messages.dart
@@ -537,7 +537,7 @@ abstract class MapViewApi {
   void removeCircles(int viewId, List<CircleDto> circles);
   void clearCircles(int viewId);
 
-  void registerOnCameraChangedListener(int viewId);
+  void enableOnCameraChangedEvents(int viewId);
   void setPadding(int viewId, MapPaddingDto padding);
   MapPaddingDto getPadding(int viewId);
 }
@@ -1403,7 +1403,7 @@ abstract class AutoMapViewApi {
   void removeCircles(List<CircleDto> circles);
   void clearCircles();
 
-  void registerOnCameraChangedListener();
+  void enableOnCameraChangedEvents();
   bool isAutoScreenAvailable();
   void setPadding(MapPaddingDto padding);
   MapPaddingDto getPadding();

--- a/test/google_navigation_flutter_test.mocks.dart
+++ b/test/google_navigation_flutter_test.mocks.dart
@@ -1726,9 +1726,9 @@ class MockTestMapViewApi extends _i1.Mock implements _i3.TestMapViewApi {
       );
 
   @override
-  void registerOnCameraChangedListener(int? viewId) => super.noSuchMethod(
+  void enableOnCameraChangedEvents(int? viewId) => super.noSuchMethod(
         Invocation.method(
-          #registerOnCameraChangedListener,
+          #enableOnCameraChangedEvents,
           [viewId],
         ),
         returnValueForMissingStub: null,

--- a/test/messages_test.g.dart
+++ b/test/messages_test.g.dart
@@ -343,7 +343,7 @@ abstract class TestMapViewApi {
 
   void clearCircles(int viewId);
 
-  void registerOnCameraChangedListener(int viewId);
+  void enableOnCameraChangedEvents(int viewId);
 
   void setPadding(int viewId, MapPaddingDto padding);
 
@@ -3465,7 +3465,7 @@ abstract class TestMapViewApi {
     {
       final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
               Object?>(
-          'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.registerOnCameraChangedListener',
+          'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.enableOnCameraChangedEvents',
           pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
@@ -3476,13 +3476,13 @@ abstract class TestMapViewApi {
             .setMockDecodedMessageHandler<Object?>(__pigeon_channel,
                 (Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.registerOnCameraChangedListener was null.');
+              'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.enableOnCameraChangedEvents was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final int? arg_viewId = (args[0] as int?);
           assert(arg_viewId != null,
-              'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.registerOnCameraChangedListener was null, expected non-null int.');
+              'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.enableOnCameraChangedEvents was null, expected non-null int.');
           try {
-            api.registerOnCameraChangedListener(arg_viewId!);
+            api.enableOnCameraChangedEvents(arg_viewId!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);


### PR DESCRIPTION
Make sure view event listeners are initialized as soon as view is created to avoid missing view events on map initialization.
Intergration tests fail time to time as some event related to map initialization never occur; reason most likely is that listeners are initialized a bit late. This PR moves event listener initialization right after platform view is created and viewId is known. View controller is returned after mapView is initialized as before.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/