### PR TITLE
test: pin patrol version to 3.14.1 to fix hanging tests

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -294,7 +294,12 @@ jobs:
         run: flutter build apk --config-only
       - name: Run integration tests
         working-directory: ${{ env.working_directory }}
-        run: patrol test --verbose
+        run: |
+          debug_flags=""
+          if [ "$ACTIONS_STEP_DEBUG" = "true" ]; then
+            debug_flags="--show-flutter-logs --verbose"
+          fi
+          patrol test  $debug_flags
       - name: Upload test report
         uses: actions/upload-artifact@v4
         if: ${{ always() }}
@@ -378,7 +383,11 @@ jobs:
         id: tests_step
         working-directory: ${{ env.working_directory }}
         run: |
-          patrol test --dart-define=MAPS_API_KEY="$MAPS_API_KEY" --verbose -d "$DEVICE_ID"
+          debug_flags=""
+          if [ "$ACTIONS_STEP_DEBUG" = "true" ]; then
+            debug_flags="--show-flutter-logs --verbose"
+          fi
+          patrol test --dart-define=MAPS_API_KEY="$MAPS_API_KEY" $debug_flags -d "$DEVICE_ID"
       - name: Upload test report
         uses: actions/upload-artifact@v4
         if: ${{ always() }}

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -296,11 +296,7 @@ jobs:
       - name: Run integration tests
         working-directory: ${{ env.working_directory }}
         run: |
-          debug_flags=""
-          if [ "$ACTIONS_STEP_DEBUG" = "true" ]; then
-            debug_flags="--show-flutter-logs --verbose"
-          fi
-          patrol test  $debug_flags
+          patrol test ${{ runner.debug && '--show-flutter-logs --verbose' || '' }}
       - name: Upload test report
         uses: actions/upload-artifact@v4
         if: ${{ always() }}
@@ -385,11 +381,7 @@ jobs:
         id: tests_step
         working-directory: ${{ env.working_directory }}
         run: |
-          debug_flags=""
-          if [ "$ACTIONS_STEP_DEBUG" = "true" ]; then
-            debug_flags="--show-flutter-logs --verbose"
-          fi
-          patrol test --dart-define=MAPS_API_KEY="$MAPS_API_KEY" $debug_flags -d "$DEVICE_ID"
+          patrol test --dart-define=MAPS_API_KEY="$MAPS_API_KEY" ${{ runner.debug && '--show-flutter-logs --verbose' || '' }} -d "$DEVICE_ID"
       - name: Upload test report
         uses: actions/upload-artifact@v4
         if: ${{ always() }}

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -225,6 +225,7 @@ jobs:
       labels: ubuntu-latest
     env:
       MAPS_API_KEY: ${{ secrets.ACTIONS_API_KEY }}
+      PATROL_ANALYTICS_ENABLED: false
       patrol_cli_version: "3.5.0"
       working_directory: "example"
     steps:
@@ -317,6 +318,7 @@ jobs:
       labels: macos-latest-xlarge
     env:
       MAPS_API_KEY: ${{ secrets.ACTIONS_API_KEY }}
+      PATROL_ANALYTICS_ENABLED: false
       patrol_cli_version: "3.5.0"
       working_directory: "example"
     steps:

--- a/example/integration_test/shared.dart
+++ b/example/integration_test/shared.dart
@@ -163,12 +163,11 @@ Future<void> checkLocationDialogAcceptance(PatrolIntegrationTester $) async {
     final Future<PermissionStatus> locationGranted =
         Permission.locationWhenInUse.request();
 
-    // Wait for the dialog to be shown, otherwise patrol sometimes clicks
-    // before the dialog accepts the clicks.
-    await $.pumpAndSettle();
-
-    // Grant location permission.
-    await $.native.grantPermissionWhenInUse();
+    if (await $.native
+        .isPermissionDialogVisible(timeout: const Duration(seconds: 5))) {
+      // Grant location permission.
+      await $.native.grantPermissionWhenInUse();
+    }
 
     // Check that the location permission is granted.
     await locationGranted.then((PermissionStatus status) async {

--- a/example/integration_test/shared.dart
+++ b/example/integration_test/shared.dart
@@ -163,6 +163,10 @@ Future<void> checkLocationDialogAcceptance(PatrolIntegrationTester $) async {
     final Future<PermissionStatus> locationGranted =
         Permission.locationWhenInUse.request();
 
+    // Wait for the dialog to be shown, otherwise patrol sometimes clicks
+    // before the dialog accepts the clicks.
+    await $.pumpAndSettle();
+
     // Grant location permission.
     await $.native.grantPermissionWhenInUse();
 

--- a/example/integration_test/t01_initialization_test.dart
+++ b/example/integration_test/t01_initialization_test.dart
@@ -28,7 +28,15 @@ import 'package:flutter/material.dart';
 import 'shared.dart';
 
 void main() {
-  patrol('Test session initialization errors',
+  // Patrol runs the tests in alphabetical order, add a prefix to the test
+  // name to control the order with script:
+  int testCounter = 0;
+  String prefix(String name) {
+    testCounter++;
+    return 'IT${testCounter.toString().padLeft(2, '0')} $name';
+  }
+
+  patrol(prefix('Test session initialization errors'),
       (PatrolIntegrationTester $) async {
     await GoogleMapsNavigator.resetTermsAccepted();
     expect(await GoogleMapsNavigator.areTermsAccepted(), false);
@@ -174,7 +182,7 @@ void main() {
     }
   });
 
-  patrol('Test Maps initialization', (PatrolIntegrationTester $) async {
+  patrol(prefix('Test Maps initialization'), (PatrolIntegrationTester $) async {
     final Completer<GoogleNavigationViewController> viewControllerCompleter =
         Completer<GoogleNavigationViewController>();
 
@@ -266,7 +274,7 @@ void main() {
     expect(await controller.isNavigationUIEnabled(), true);
   });
 
-  patrol('Test Maps initialization without navigation',
+  patrol(prefix('Test Maps initialization without navigation'),
       (PatrolIntegrationTester $) async {
     final Completer<GoogleMapViewController> viewControllerCompleter =
         Completer<GoogleMapViewController>();

--- a/example/integration_test/t01_initialization_test.dart
+++ b/example/integration_test/t01_initialization_test.dart
@@ -28,7 +28,7 @@ import 'package:flutter/material.dart';
 import 'shared.dart';
 
 void main() {
-  patrol('C01 - Test session initialization errors',
+  patrol('Test session initialization errors',
       (PatrolIntegrationTester $) async {
     await GoogleMapsNavigator.resetTermsAccepted();
     expect(await GoogleMapsNavigator.areTermsAccepted(), false);
@@ -174,7 +174,7 @@ void main() {
     }
   });
 
-  patrol('C02 - Test Maps initialization', (PatrolIntegrationTester $) async {
+  patrol('Test Maps initialization', (PatrolIntegrationTester $) async {
     final Completer<GoogleNavigationViewController> viewControllerCompleter =
         Completer<GoogleNavigationViewController>();
 
@@ -266,7 +266,7 @@ void main() {
     expect(await controller.isNavigationUIEnabled(), true);
   });
 
-  patrol('C03 - Test Maps initialization without navigation',
+  patrol('Test Maps initialization without navigation',
       (PatrolIntegrationTester $) async {
     final Completer<GoogleMapViewController> viewControllerCompleter =
         Completer<GoogleMapViewController>();

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,7 +36,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   meta: any
-  patrol: ^3.14.0
+  patrol: 3.14.1 # Patrol 3.15.1 has hang issues on Android. Pinging to 3.14.1 for now.
   pub_semver: ^2.1.4
   test_api: any
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -51,7 +51,7 @@ scripts:
   format:
     run: |
       melos run format:dart && \
-      melos run format:ios &&  \
+      melos run format:ios && \
       melos run format:android
     description: |
       Formats the code of all packages (Dart, iOS, Android).


### PR DESCRIPTION
Latest patrol version 3.15.1 have issues that cause hanging CI. Pinning the patrol version to 3.14.1 for now.
Also remove verbose flag from integration tests. Verbose flag can separately be enabled with enabling debug logs for github actions workflow.

Related to https://github.com/googlemaps/flutter-navigation-sdk/issues/167

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/