### PR TITLE
fix: hide report incident button from the carplay view

### DIFF
--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/BaseCarSceneDelegate.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/BaseCarSceneDelegate.swift
@@ -103,6 +103,7 @@ open class BaseCarSceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate
         self.navView?.setRecenterButtonEnabled(false)
         self.navView?.setNavigationFooterEnabled(false)
         self.navView?.setSpeedometerEnabled(false)
+        self.navView?.setReportIncidentButtonEnabled(false)
         self.navViewController = UIViewController()
         self.navViewController?.view = self.navView?.view()
         self.carWindow?.rootViewController = self.navViewController


### PR DESCRIPTION
Hides the Report Incident button introduced in the latest SDK version from the CarPlay view, as it cannot be interacted with.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/