### PR TITLE
fix: add assert to NavigationWaypoint constructor

### DIFF
--- a/lib/src/types/navigation_destinations.dart
+++ b/lib/src/types/navigation_destinations.dart
@@ -182,6 +182,9 @@ class NavigationDisplayOptions {
 
 /// Navigation waypoint with different constructors based in on type of
 /// initialization.
+///
+/// Either a [target] in the form of [LatLng] or a [placeID] must be provided.
+///
 /// {@category Navigation}
 class NavigationWaypoint {
   /// Initializer for [NavigationWaypoint].
@@ -194,6 +197,10 @@ class NavigationWaypoint {
   }) : assert(
          target != null || placeID != null,
          'Either target or placeID must be provided',
+       ),
+       assert(
+         target == null || placeID == null,
+         'Cannot provide both target and placeID at the same time.',
        );
 
   /// Initialize waypoint with coordinates.

--- a/test/google_navigation_flutter_test.dart
+++ b/test/google_navigation_flutter_test.dart
@@ -1010,8 +1010,14 @@ void main() {
           expect(waypointOut, isNotNull);
           if (waypointOut != null) {
             expect(targetWaypointIn.title, waypointOut.title);
-            expect(targetWaypointIn.target?.latitude, waypointOut.target?.latitude);
-            expect(targetWaypointIn.target?.longitude, waypointOut.target?.longitude);
+            expect(
+              targetWaypointIn.target?.latitude,
+              waypointOut.target?.latitude,
+            );
+            expect(
+              targetWaypointIn.target?.longitude,
+              waypointOut.target?.longitude,
+            );
             expect(
               targetWaypointIn.preferSameSideOfRoad,
               waypointOut.preferSameSideOfRoad,

--- a/test/google_navigation_flutter_test.dart
+++ b/test/google_navigation_flutter_test.dart
@@ -995,31 +995,29 @@ void main() {
           }
 
           // Continue to the next destination.
-          final NavigationWaypointDto waypointIn = NavigationWaypointDto(
+          final NavigationWaypointDto targetWaypointIn = NavigationWaypointDto(
             title: 'Title',
             target: LatLngDto(latitude: 0.4, longitude: 0.5),
-            placeID: 'id',
             preferSameSideOfRoad: true,
             preferredSegmentHeading: 50,
           );
 
           when(
             sessionMockApi.continueToNextDestination(),
-          ).thenReturn(waypointIn);
+          ).thenReturn(targetWaypointIn);
           final NavigationWaypoint? waypointOut =
               await GoogleMapsNavigator.continueToNextDestination();
           expect(waypointOut, isNotNull);
           if (waypointOut != null) {
-            expect(waypointIn.title, waypointOut.title);
-            expect(waypointIn.target?.latitude, waypointOut.target?.latitude);
-            expect(waypointIn.target?.longitude, waypointOut.target?.longitude);
-            expect(waypointIn.placeID, waypointOut.placeID);
+            expect(targetWaypointIn.title, waypointOut.title);
+            expect(targetWaypointIn.target?.latitude, waypointOut.target?.latitude);
+            expect(targetWaypointIn.target?.longitude, waypointOut.target?.longitude);
             expect(
-              waypointIn.preferSameSideOfRoad,
+              targetWaypointIn.preferSameSideOfRoad,
               waypointOut.preferSameSideOfRoad,
             );
             expect(
-              waypointIn.preferredSegmentHeading,
+              targetWaypointIn.preferredSegmentHeading,
               waypointOut.preferredSegmentHeading,
             );
           }

--- a/test/navigation_types_test.dart
+++ b/test/navigation_types_test.dart
@@ -18,16 +18,22 @@ import 'package:google_navigation_flutter/src/method_channel/convert/navigation_
 import 'package:google_navigation_flutter/src/method_channel/method_channel.dart';
 
 void main() {
-  late NavigationWaypointDto waypointDto;
+  late NavigationWaypointDto placeIDWaypointDto;
+  late NavigationWaypointDto targetWaypointDto;
   late NavigationWaypoint waypoint;
   late Destinations destinations;
   late NavigationDisplayOptions displayOptions;
   late RoutingOptions routingOptions;
 
   setUp(() {
-    waypointDto = NavigationWaypointDto(
+    targetWaypointDto = NavigationWaypointDto(
       title: 'testTitle',
       target: LatLngDto(latitude: 5.0, longitude: 6.0),
+      preferSameSideOfRoad: true,
+      preferredSegmentHeading: 50,
+    );
+    placeIDWaypointDto = NavigationWaypointDto(
+      title: 'testTitle',
       placeID: 'testID',
       preferSameSideOfRoad: true,
       preferredSegmentHeading: 50,
@@ -58,18 +64,46 @@ void main() {
 
   group('NavigationWaypoint tests', () {
     test('tests Navigation Waypoint conversion from DTO', () {
-      final NavigationWaypoint gmsWaypoint = waypointDto.toNavigationWaypoint();
-      expect(gmsWaypoint.title, waypointDto.title);
-      expect(gmsWaypoint.target?.latitude, waypointDto.target?.latitude);
-      expect(gmsWaypoint.target?.longitude, waypointDto.target?.longitude);
-      expect(gmsWaypoint.placeID, waypointDto.placeID);
+      final NavigationWaypoint targetGmsWaypoint =
+          targetWaypointDto.toNavigationWaypoint();
+      expect(targetGmsWaypoint.title, targetWaypointDto.title);
       expect(
-        gmsWaypoint.preferSameSideOfRoad,
-        waypointDto.preferSameSideOfRoad,
+        targetGmsWaypoint.target?.latitude,
+        targetWaypointDto.target?.latitude,
       );
       expect(
-        gmsWaypoint.preferredSegmentHeading,
-        waypointDto.preferredSegmentHeading,
+        targetGmsWaypoint.target?.longitude,
+        targetWaypointDto.target?.longitude,
+      );
+      expect(targetGmsWaypoint.placeID, targetWaypointDto.placeID);
+      expect(
+        targetGmsWaypoint.preferSameSideOfRoad,
+        targetWaypointDto.preferSameSideOfRoad,
+      );
+      expect(
+        targetGmsWaypoint.preferredSegmentHeading,
+        targetWaypointDto.preferredSegmentHeading,
+      );
+
+      final NavigationWaypoint placeIDGmsWaypoint =
+          placeIDWaypointDto.toNavigationWaypoint();
+      expect(placeIDGmsWaypoint.title, placeIDWaypointDto.title);
+      expect(
+        placeIDGmsWaypoint.target?.latitude,
+        placeIDWaypointDto.target?.latitude,
+      );
+      expect(
+        placeIDGmsWaypoint.target?.longitude,
+        placeIDWaypointDto.target?.longitude,
+      );
+      expect(placeIDGmsWaypoint.placeID, placeIDWaypointDto.placeID);
+      expect(
+        placeIDGmsWaypoint.preferSameSideOfRoad,
+        placeIDWaypointDto.preferSameSideOfRoad,
+      );
+      expect(
+        placeIDGmsWaypoint.preferredSegmentHeading,
+        placeIDWaypointDto.preferredSegmentHeading,
       );
     });
 
@@ -84,6 +118,19 @@ void main() {
         waypoint.preferredSegmentHeading,
         waypointDto2.preferredSegmentHeading,
       );
+    });
+
+    test('tests Navigation Waypoint creation asserts', () {
+      expect(
+        () => NavigationWaypoint(
+          title: 'test',
+          target: const LatLng(latitude: 5.0, longitude: 6.0),
+          placeID: 'testID',
+        ),
+        throwsAssertionError,
+      );
+
+      expect(() => NavigationWaypoint(title: 'test'), throwsAssertionError);
     });
   });
 


### PR DESCRIPTION
- Add assert to not allow creating NavigationWaypoint with both target and placeID.

Fixes: #382 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/