### PR TITLE
fix: fix background location updates on iOS

### DIFF
--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationSessionManager.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationSessionManager.swift
@@ -450,6 +450,7 @@ class GoogleMapsNavigationSessionManager: NSObject {
 
   func allowBackgroundLocationUpdates(allow: Bool) {
     LocationManager.shared.allowBackgroundLocationUpdates(allow: allow)
+    _session?.roadSnappedLocationProvider?.allowsBackgroundLocationUpdates = allow
   }
 
   func setSpeedAlertOptions(options: SpeedAlertOptionsDto) throws {


### PR DESCRIPTION
This PR fixes issue where GoogleMapsNavigator.allowBackgroundLocationUpdates function was not working on iOS. 

Fixes: https://github.com/googlemaps/flutter-navigation-sdk/issues/400

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/