### PR TITLE
docs: add a note about user location in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ class _NavigationSampleState extends State<NavigationSample> {
 }
 ```
 
+> [!NOTE]
+> Route calculation is only available after the Navigation SDK has successfully acquired the user's location. If the location is not yet available when trying to set a destination, the SDK will return a NavigationRouteStatus.locationUnavailable status.
+>
+> To avoid this, ensure that the SDK has provided a valid user location before calling the setDestinations function. You can do this by subscribing to the RoadSnappedLocationUpdatedEvent and waiting for the first valid location update.
+
 #### Task Removed Behavior
 
 The `taskRemovedBehavior` parameter of navigation session initialization defines how the navigation should behave when a task is removed from the recent apps list on Android. It can either:


### PR DESCRIPTION
Readme update for the set destinations part regarding waiting for initial user location.
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/