### PR TITLE
feat: deprecate continueToNextDestination method

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           path: /home/linuxbrew/.linuxbrew
           key: ${{ runner.os }}-linuxbrew
-      - name: Install swift-format 601.0.0
+      - name: Install swift-format 602.0.0
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -28,6 +28,8 @@ analyzer:
   errors:
     # allow self-reference to deprecated members
     deprecated_member_use_from_same_package: ignore
+    # allow deprecated member use in test files and examples
+    deprecated_member_use: ignore
   exclude:
     # Ignore generated files
     - "**/*.g.dart"

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -58,7 +58,7 @@ android {
         applicationId = "com.google.maps.flutter.navigation_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = 23
+        minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/example/integration_test/t01_initialization_test.dart
+++ b/example/integration_test/t01_initialization_test.dart
@@ -123,6 +123,8 @@ void main() {
     }
 
     try {
+      // Note: Testing deprecated continueToNextDestination for proper exception
+      // handling.
       await GoogleMapsNavigator.continueToNextDestination();
       fail('Expected SessionNotInitializedException.');
     } on Exception catch (e) {

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsAutoViewMessageHandler.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsAutoViewMessageHandler.swift
@@ -39,7 +39,7 @@ class GoogleMapsAutoViewMessageHandler: AutoMapViewApi {
         switch result {
         case .success:
           completion(.success(()))
-        case let .failure(error):
+        case .failure(let error):
           completion(.failure(error))
         }
       }
@@ -207,12 +207,13 @@ class GoogleMapsAutoViewMessageHandler: AutoMapViewApi {
   func animateCameraToLatLngBounds(
     bounds: LatLngBoundsDto,
     padding: Double, duration: Int64?,
-    completion: @escaping (
-      Result<
-        Bool,
-        Error
-      >
-    )
+    completion:
+      @escaping (
+        Result<
+          Bool,
+          Error
+        >
+      )
       -> Void
   ) {
     do {
@@ -264,12 +265,13 @@ class GoogleMapsAutoViewMessageHandler: AutoMapViewApi {
   func animateCameraByZoom(
     zoomBy: Double, focusDx: Double?,
     focusDy: Double?, duration: Int64?,
-    completion: @escaping (
-      Result<
-        Bool,
-        Error
-      >
-    ) -> Void
+    completion:
+      @escaping (
+        Result<
+          Bool,
+          Error
+        >
+      ) -> Void
   ) {
     do {
       let focus = Convert.convertDeltaToPoint(dx: focusDx, dy: focusDy)

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationSessionManager.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationSessionManager.swift
@@ -349,12 +349,13 @@ class GoogleMapsNavigationSessionManager: NSObject {
 
   func simulateLocationsAlongNewRoute(
     waypoints: [NavigationWaypointDto],
-    completion: @escaping (
-      Result<
-        RouteStatusDto,
-        Error
-      >
-    )
+    completion:
+      @escaping (
+        Result<
+          RouteStatusDto,
+          Error
+        >
+      )
       -> Void
   ) throws {
     /// Speedmultiplier is set to default value here because the functions using
@@ -394,12 +395,13 @@ class GoogleMapsNavigationSessionManager: NSObject {
   func simulateLocationsAlongNewRouteWithRoutingOptions(
     waypoints: [NavigationWaypointDto],
     routingOptions: RoutingOptionsDto,
-    completion: @escaping (
-      Result<
-        RouteStatusDto,
-        Error
-      >
-    ) -> Void
+    completion:
+      @escaping (
+        Result<
+          RouteStatusDto,
+          Error
+        >
+      ) -> Void
   ) throws {
     /// Speedmultiplier is set to default value here because the functions using
     /// SimulationOptionsDto will set it globally to a custom value. This
@@ -421,12 +423,13 @@ class GoogleMapsNavigationSessionManager: NSObject {
     waypoints: [NavigationWaypointDto],
     routingOptions: RoutingOptionsDto,
     simulationOptions: SimulationOptionsDto,
-    completion: @escaping (
-      Result<
-        RouteStatusDto,
-        Error
-      >
-    ) -> Void
+    completion:
+      @escaping (
+        Result<
+          RouteStatusDto,
+          Error
+        >
+      ) -> Void
   ) throws {
     try getSimulator().speedMultiplier = Float(simulationOptions.speedMultiplier)
     try setRoutingOptionsGlobals(routingOptions, for: .simulator)

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationSessionMessageHandler.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationSessionMessageHandler.swift
@@ -143,12 +143,13 @@ class GoogleMapsNavigationSessionMessageHandler: NavigationSessionApi {
 
   func simulateLocationsAlongNewRoute(
     waypoints: [NavigationWaypointDto],
-    completion: @escaping (
-      Result<
-        RouteStatusDto,
-        Error
-      >
-    )
+    completion:
+      @escaping (
+        Result<
+          RouteStatusDto,
+          Error
+        >
+      )
       -> Void
   ) {
     do {
@@ -164,12 +165,13 @@ class GoogleMapsNavigationSessionMessageHandler: NavigationSessionApi {
   func simulateLocationsAlongNewRouteWithRoutingOptions(
     waypoints: [NavigationWaypointDto],
     routingOptions: RoutingOptionsDto,
-    completion: @escaping (
-      Result<
-        RouteStatusDto,
-        Error
-      >
-    ) -> Void
+    completion:
+      @escaping (
+        Result<
+          RouteStatusDto,
+          Error
+        >
+      ) -> Void
   ) {
     do {
       try GoogleMapsNavigationSessionManager.shared
@@ -187,12 +189,13 @@ class GoogleMapsNavigationSessionMessageHandler: NavigationSessionApi {
     waypoints: [NavigationWaypointDto],
     routingOptions: RoutingOptionsDto,
     simulationOptions: SimulationOptionsDto,
-    completion: @escaping (
-      Result<
-        RouteStatusDto,
-        Error
-      >
-    ) -> Void
+    completion:
+      @escaping (
+        Result<
+          RouteStatusDto,
+          Error
+        >
+      ) -> Void
   ) {
     do {
       try GoogleMapsNavigationSessionManager.shared

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewMessageHandler.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewMessageHandler.swift
@@ -40,7 +40,7 @@ class GoogleMapsNavigationViewMessageHandler: MapViewApi {
         switch result {
         case .success:
           completion(.success(()))
-        case let .failure(error):
+        case .failure(let error):
           completion(.failure(error))
         }
       }
@@ -208,12 +208,13 @@ class GoogleMapsNavigationViewMessageHandler: MapViewApi {
   func animateCameraToLatLngBounds(
     viewId: Int64, bounds: LatLngBoundsDto,
     padding: Double, duration: Int64?,
-    completion: @escaping (
-      Result<
-        Bool,
-        Error
-      >
-    ) -> Void
+    completion:
+      @escaping (
+        Result<
+          Bool,
+          Error
+        >
+      ) -> Void
   ) {
     do {
       try getView(viewId).animateCameraToLatLngBounds(
@@ -264,12 +265,13 @@ class GoogleMapsNavigationViewMessageHandler: MapViewApi {
   func animateCameraByZoom(
     viewId: Int64, zoomBy: Double, focusDx: Double?,
     focusDy: Double?, duration: Int64?,
-    completion: @escaping (
-      Result<
-        Bool,
-        Error
-      >
-    ) -> Void
+    completion:
+      @escaping (
+        Result<
+          Bool,
+          Error
+        >
+      ) -> Void
   ) {
     do {
       let focus = Convert.convertDeltaToPoint(dx: focusDx, dy: focusDy)

--- a/lib/src/method_channel/session_api.dart
+++ b/lib/src/method_channel/session_api.dart
@@ -237,6 +237,7 @@ class NavigationSessionAPIImpl {
   }
 
   /// Continues to next waypoint.
+  @Deprecated('Use setDestinations with an updated list of waypoints instead')
   Future<NavigationWaypoint?> continueToNextDestination() async {
     try {
       final NavigationWaypointDto? waypointDto =

--- a/lib/src/navigator/google_navigation_flutter_navigator.dart
+++ b/lib/src/navigator/google_navigation_flutter_navigator.dart
@@ -543,6 +543,10 @@ class GoogleMapsNavigator {
   /// Removes the current waypoint.
   /// Following this call, guidance will be toward the next destination,
   /// and information about the old destination is not available.
+  ///
+  /// Deprecated: Use [setDestinations] with an updated list of waypoints
+  /// instead. This approach provides better control over the navigation route.
+  @Deprecated('Use setDestinations with an updated list of waypoints instead')
   static Future<NavigationWaypoint?> continueToNextDestination() {
     return GoogleMapsNavigationPlatform.instance.navigationSessionAPI
         .continueToNextDestination();


### PR DESCRIPTION
Deprecates continueToNextDestination navigation method.
Developers should start using setDestinations call with updated list of waypoints instead.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/