### PR TITLE
fix: ios view registration race condition

### DIFF
--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationView.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationView.swift
@@ -134,7 +134,7 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
     } else {
       if let _viewId {
         let viewInstanceId = ObjectIdentifier(self)
-        _viewRegistry.unregisterView(viewId: _viewId, viewIdToUnregister: viewInstanceId)
+        _viewRegistry.unregisterView(viewId: _viewId, viewInstanceIdToUnregister: viewInstanceId)
       }
     }
   }

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewRegistry.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewRegistry.swift
@@ -40,7 +40,9 @@ class GoogleMapsNavigationViewRegistry {
 
   func unregisterView(viewId: Int64, viewInstanceIdToUnregister: ObjectIdentifier) {
     queue.async(flags: .barrier) { [weak self] in
-      if let registeredView = self?.views[viewId], ObjectIdentifier(registeredView) == viewIdToUnregister {
+      if let registeredView = self?.views[viewId],
+        ObjectIdentifier(registeredView) == viewInstanceIdToUnregister
+      {
         self?.views.removeValue(forKey: viewId)
       }
     }


### PR DESCRIPTION
Fixes to iOS view registration logic that previously caused some issues like onViewCreated not being triggered on iOS when doing hot restart with Flutter.

Fixes: https://github.com/googlemaps/flutter-navigation-sdk/issues/541

Fix based on a code suggestion from user @bderrien

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/