### PR TITLE
feat: upgrade Navigation SDK for iOS to 10.7.0

### DIFF
--- a/ios/google_navigation_flutter.podspec
+++ b/ios/google_navigation_flutter.podspec
@@ -15,7 +15,7 @@ A Google Maps Navigation Flutter plugin.
   s.source           = { :path => '.' }
   s.source_files = 'google_navigation_flutter/Sources/google_navigation_flutter/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'GoogleNavigation', '10.6.0'
+  s.dependency 'GoogleNavigation', '10.7.0'
   s.platform = :ios, '16.0'
   s.static_framework = true
 

--- a/ios/google_navigation_flutter/Package.swift
+++ b/ios/google_navigation_flutter/Package.swift
@@ -28,11 +28,11 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/googlemaps/ios-navigation-sdk",
-      exact: "10.6.0"
+      exact: "10.7.0"
     ),
     .package(
       url: "https://github.com/googlemaps/ios-maps-sdk",
-      exact: "10.6.0"
+      exact: "10.7.0"
     ),
   ],
   targets: [


### PR DESCRIPTION
This PR upgrades the Navigation SDK for iOS version to 7.3.0 and includes the following improvements:
- Route-aware road labeling. This feature declutters the map by using the current route as context. Route-aware labeling removes road labels for low-priority roads that don't intersect with the route.
- Voice guidance improvements. Improvements to voice guidance are included in this release, including more varied messages. This means users will hear messages like, "take the next left" in addition to or instead of messages like, "in 0.2 miles, turn left."
- Fixed: Crash in Unusual Initialization Cases. A crash that occurred in unusual (but supported) initialization conditions was fixed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/