### PR TITLE
fix: filter out null from navigation steps on android

### DIFF
--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsNavigationSessionManager.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsNavigationSessionManager.kt
@@ -812,24 +812,24 @@ constructor(
         (navInfo.remainingSteps + navInfo.currentStep)
           .filter { it != null }
           .forEach { stepInfo ->
-          // Handle maneuver images
-          if (generateManeuverImages) {
-            val maneuverKey = Convert.convertManeuverToKey(stepInfo.maneuver)
-            if (!imageDescriptors.containsKey(maneuverKey)) {
-              val imageDescriptor = getManeuverImageDescriptorForStepInfo(stepInfo)
-              imageDescriptors[maneuverKey] = imageDescriptor
+            // Handle maneuver images
+            if (generateManeuverImages) {
+              val maneuverKey = Convert.convertManeuverToKey(stepInfo.maneuver)
+              if (!imageDescriptors.containsKey(maneuverKey)) {
+                val imageDescriptor = getManeuverImageDescriptorForStepInfo(stepInfo)
+                imageDescriptors[maneuverKey] = imageDescriptor
+              }
             }
-          }
 
-          // Handle lane images
-          if (generateLaneImages && !stepInfo.lanes.isNullOrEmpty()) {
-            val laneKey = Convert.convertLanesToKey(stepInfo)
-            if (!imageDescriptors.containsKey(laneKey)) {
-              val imageDescriptor = getLanesImageDescriptorForStepInfo(stepInfo)
-              imageDescriptors[laneKey] = imageDescriptor
+            // Handle lane images
+            if (generateLaneImages && !stepInfo.lanes.isNullOrEmpty()) {
+              val laneKey = Convert.convertLanesToKey(stepInfo)
+              if (!imageDescriptors.containsKey(laneKey)) {
+                val imageDescriptor = getLanesImageDescriptorForStepInfo(stepInfo)
+                imageDescriptors[laneKey] = imageDescriptor
+              }
             }
           }
-        }
 
         navigationSessionEventApi.onNavInfo(Convert.convertNavInfo(navInfo, imageDescriptors)) {}
       }


### PR DESCRIPTION
Filter out null steps from Android maneuver/lane images processing on Android.

Fixes: https://github.com/googlemaps/flutter-navigation-sdk/issues/589

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/