### PR TITLE
feat: upgrade Android SDK to 7.6.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -78,7 +78,7 @@ android {
         implementation 'androidx.car.app:app:1.7.0'
         implementation 'androidx.car.app:app-projected:1.7.0'
         implementation 'androidx.startup:startup-runtime:1.2.0'
-        implementation 'com.google.android.libraries.navigation:navigation:7.6.0'
+        implementation 'com.google.android.libraries.navigation:navigation:7.6.1'
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'io.mockk:mockk:1.13.8'
         testImplementation 'junit:junit:4.13.2'

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -103,7 +103,7 @@ flutter {
 dependencies {
     implementation("androidx.car.app:app:1.7.0")
     implementation("androidx.car.app:app-projected:1.7.0")
-    implementation("com.google.android.libraries.navigation:navigation:7.6.0")
+    implementation("com.google.android.libraries.navigation:navigation:7.6.1")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs_nio:2.0.4")
     androidTestUtil("androidx.test:orchestrator:1.5.1")
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -17,3 +17,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.builtInKotlin=false
+android.newDsl=false


### PR DESCRIPTION
Upgrades Android SDK to 7.6.1
See release notes at: https://developers.google.com/maps/documentation/navigation/android-sdk/release-notes#May_13_2026

Closes #689

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/