### PR TITLE
feat: upgrade iOS SDK to 10.13.0

### DIFF
--- a/ios/google_navigation_flutter.podspec
+++ b/ios/google_navigation_flutter.podspec
@@ -15,7 +15,7 @@ A Google Maps Navigation Flutter plugin.
   s.source           = { :path => '.' }
   s.source_files = 'google_navigation_flutter/Sources/google_navigation_flutter/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'GoogleNavigation', '10.12.0'
+  s.dependency 'GoogleNavigation', '10.13.0'
   s.platform = :ios, '16.0'
   s.static_framework = true
 

--- a/ios/google_navigation_flutter/Package.swift
+++ b/ios/google_navigation_flutter/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
     .library(name: "google-navigation-flutter", targets: ["google_navigation_flutter"])
   ],
   dependencies: [
+    .package(name: "FlutterFramework", path: "../FlutterFramework"),
     .package(
       url: "https://github.com/googlemaps/ios-navigation-sdk",
       exact: "10.13.0"
@@ -39,6 +40,7 @@ let package = Package(
     .target(
       name: "google_navigation_flutter",
       dependencies: [
+        .product(name: "FlutterFramework", package: "FlutterFramework"),
         .product(
           name: "GoogleNavigation",
           package: "ios-navigation-sdk"

--- a/ios/google_navigation_flutter/Package.swift
+++ b/ios/google_navigation_flutter/Package.swift
@@ -28,11 +28,11 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/googlemaps/ios-navigation-sdk",
-      exact: "10.12.0"
+      exact: "10.13.0"
     ),
     .package(
       url: "https://github.com/googlemaps/ios-maps-sdk",
-      exact: "10.12.0"
+      exact: "10.13.0"
     ),
   ],
   targets: [


### PR DESCRIPTION
Upgrades iOS SDK to 10.13.0
See release notes at: https://developers.google.com/maps/documentation/navigation/ios-sdk/release-notes#April_30_2026

Closes #690

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/