### PR TITLE
feat: add indoor map controls for map and navigation views

### DIFF
--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/AndroidAutoBaseScreen.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/AndroidAutoBaseScreen.kt
@@ -35,6 +35,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.GoogleMapOptions
+import com.google.android.gms.maps.model.IndoorBuilding
 import com.google.android.libraries.navigation.NavigationView
 import com.google.android.libraries.navigation.PromptVisibilityChangedListener
 
@@ -201,6 +202,10 @@ open class AndroidAutoBaseScreen(carContext: CarContext) :
       // Guard against race condition where surface is destroyed before getMapAsync completes
       if (mIsSurfaceDestroyed) return@getMapAsync
 
+      // Indoor level picker is not user-operable on Android Auto,
+      // so keep it disabled by default for auto surfaces.
+      googleMap.uiSettings.isIndoorLevelPickerEnabled = false
+
       val viewRegistry = GoogleMapsNavigationPlugin.getInstance()?.viewRegistry
       val imageRegistry = GoogleMapsNavigationPlugin.getInstance()?.imageRegistry
       if (viewRegistry != null && imageRegistry != null) {
@@ -216,6 +221,18 @@ open class AndroidAutoBaseScreen(carContext: CarContext) :
             navigationView,
             googleMap,
           )
+
+        googleMap.setOnIndoorStateChangeListener(
+          object : GoogleMap.OnIndoorStateChangeListener {
+            override fun onIndoorBuildingFocused() {
+              sendIndoorFocusedBuildingChangedEvent(mAutoMapView?.getFocusedIndoorBuilding())
+            }
+
+            override fun onIndoorLevelActivated(indoorBuilding: IndoorBuilding) {
+              sendIndoorActiveLevelChangedEvent(Convert.convertIndoorBuildingToDto(indoorBuilding))
+            }
+          }
+        )
 
         // Set up prompt visibility listener with direct access to NavigationView
         mPromptVisibilityListener = PromptVisibilityChangedListener { promptVisible ->
@@ -234,6 +251,8 @@ open class AndroidAutoBaseScreen(carContext: CarContext) :
     super.onSurfaceDestroyed(surfaceContainer)
     mIsSurfaceDestroyed = true
     sendAutoScreenAvailabilityChangedEvent(false)
+
+    mGoogleMap?.setOnIndoorStateChangeListener(null)
 
     // Clean up prompt visibility listener
     if (mPromptVisibilityListener != null && mNavigationView != null) {
@@ -288,6 +307,18 @@ open class AndroidAutoBaseScreen(carContext: CarContext) :
   private fun sendAutoScreenAvailabilityChangedEvent(isAvailable: Boolean) {
     GoogleMapsNavigationPlugin.getInstance()?.autoViewEventApi?.onAutoScreenAvailabilityChanged(
       isAvailable
+    ) {}
+  }
+
+  private fun sendIndoorFocusedBuildingChangedEvent(building: IndoorBuildingDto?) {
+    GoogleMapsNavigationPlugin.getInstance()?.autoViewEventApi?.onIndoorFocusedBuildingChanged(
+      building
+    ) {}
+  }
+
+  private fun sendIndoorActiveLevelChangedEvent(building: IndoorBuildingDto?) {
+    GoogleMapsNavigationPlugin.getInstance()?.autoViewEventApi?.onIndoorActiveLevelChanged(
+      building
     ) {}
   }
 

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/Convert.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/Convert.kt
@@ -25,6 +25,8 @@ import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.Dash
 import com.google.android.gms.maps.model.Dot
 import com.google.android.gms.maps.model.Gap
+import com.google.android.gms.maps.model.IndoorBuilding
+import com.google.android.gms.maps.model.IndoorLevel
 import com.google.android.gms.maps.model.JointType
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
@@ -214,6 +216,31 @@ object Convert {
    */
   private fun convertLatLngToDto(point: LatLng): LatLngDto {
     return LatLngDto(point.latitude, point.longitude)
+  }
+
+  /**
+   * Converts Google Maps [IndoorLevel] to Pigeon [IndoorLevelDto].
+   *
+   * @param level Google Maps [IndoorLevel].
+   * @return Pigeon [IndoorLevelDto].
+   */
+  private fun convertIndoorLevelToDto(level: IndoorLevel): IndoorLevelDto {
+    return IndoorLevelDto(level.name, level.shortName)
+  }
+
+  /**
+   * Converts Google Maps [IndoorBuilding] to Pigeon [IndoorBuildingDto].
+   *
+   * @param building Google Maps [IndoorBuilding].
+   * @return Pigeon [IndoorBuildingDto].
+   */
+  fun convertIndoorBuildingToDto(building: IndoorBuilding): IndoorBuildingDto {
+    return IndoorBuildingDto(
+      levels = building.levels.map { convertIndoorLevelToDto(it) },
+      activeLevelIndex = building.activeLevelIndex.toLong(),
+      defaultLevelIndex = building.defaultLevelIndex.toLong(),
+      isUnderground = building.isUnderground,
+    )
   }
 
   /**

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoViewMessageHandler.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoViewMessageHandler.kt
@@ -460,6 +460,22 @@ class GoogleMapsAutoViewMessageHandler(private val viewRegistry: GoogleMapsViewR
     return viewRegistry.getAndroidAutoView() != null
   }
 
+  override fun isIndoorEnabled(viewId: Long): Boolean {
+    return getView().isIndoorEnabled()
+  }
+
+  override fun setIndoorEnabled(viewId: Long, enabled: Boolean) {
+    getView().setIndoorEnabled(enabled)
+  }
+
+  override fun getFocusedIndoorBuilding(viewId: Long): IndoorBuildingDto? {
+    return getView().getFocusedIndoorBuilding()
+  }
+
+  override fun activateIndoorLevel(viewId: Long, levelIndex: Long) {
+    getView().activateIndoorLevel(levelIndex.toInt())
+  }
+
   override fun setPadding(padding: MapPaddingDto) {
     getView().setPadding(padding)
   }

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoViewMessageHandler.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoViewMessageHandler.kt
@@ -460,19 +460,19 @@ class GoogleMapsAutoViewMessageHandler(private val viewRegistry: GoogleMapsViewR
     return viewRegistry.getAndroidAutoView() != null
   }
 
-  override fun isIndoorEnabled(viewId: Long): Boolean {
+  override fun isIndoorEnabled(): Boolean {
     return getView().isIndoorEnabled()
   }
 
-  override fun setIndoorEnabled(viewId: Long, enabled: Boolean) {
+  override fun setIndoorEnabled(enabled: Boolean) {
     getView().setIndoorEnabled(enabled)
   }
 
-  override fun getFocusedIndoorBuilding(viewId: Long): IndoorBuildingDto? {
+  override fun getFocusedIndoorBuilding(): IndoorBuildingDto? {
     return getView().getFocusedIndoorBuilding()
   }
 
-  override fun activateIndoorLevel(viewId: Long, levelIndex: Long) {
+  override fun activateIndoorLevel(levelIndex: Long) {
     getView().activateIndoorLevel(levelIndex.toInt())
   }
 

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsBaseMapView.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsBaseMapView.kt
@@ -31,6 +31,7 @@ import com.google.android.gms.maps.GoogleMap.OnMarkerDragListener
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.FollowMyLocationOptions
+import com.google.android.gms.maps.model.IndoorBuilding
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.MapStyleOptions
@@ -60,6 +61,7 @@ abstract class GoogleMapsBaseMapView(
   // Nullable variable to hold the callback function
   private var _mapReadyCallback: ((Result<Unit>) -> Unit)? = null
   private var _pendingCameraEventsListenerSetup = false
+  private var _indoorStateChangeListener: GoogleMap.OnIndoorStateChangeListener? = null
 
   // Default values for UI features.
   private var _consumeMyLocationButtonClickEventsEnabled: Boolean = false
@@ -254,6 +256,24 @@ abstract class GoogleMapsBaseMapView(
       ) {}
     }
 
+    _indoorStateChangeListener =
+      object : GoogleMap.OnIndoorStateChangeListener {
+        override fun onIndoorBuildingFocused() {
+          viewEventApi?.onIndoorFocusedBuildingChanged(
+            getViewId().toLong(),
+            getFocusedIndoorBuilding(),
+          ) {}
+        }
+
+        override fun onIndoorLevelActivated(indoorBuilding: IndoorBuilding) {
+          viewEventApi?.onIndoorActiveLevelChanged(
+            getViewId().toLong(),
+            Convert.convertIndoorBuildingToDto(indoorBuilding),
+          ) {}
+        }
+      }
+    getMap().setOnIndoorStateChangeListener(_indoorStateChangeListener)
+
     getMap()
       .setOnFollowMyLocationCallback(
         object : GoogleMap.OnCameraFollowLocationCallback {
@@ -293,6 +313,7 @@ abstract class GoogleMapsBaseMapView(
       setOnPolylineClickListener(null)
       setOnMyLocationClickListener(null)
       setOnMyLocationButtonClickListener(null)
+      setOnIndoorStateChangeListener(null)
       setOnFollowMyLocationCallback(null)
       setOnCameraMoveStartedListener(null)
       setOnCameraMoveListener(null)
@@ -303,6 +324,7 @@ abstract class GoogleMapsBaseMapView(
     val textureView = findTextureView(getView()) ?: return
     textureView.surfaceTextureListener = null
     _map = null
+    _indoorStateChangeListener = null
 
     currentLifecycleState = LifecycleState.DESTROYED
   }
@@ -441,6 +463,14 @@ abstract class GoogleMapsBaseMapView(
     return _maxZoomLevelPreference ?: getMap().maxZoomLevel
   }
 
+  fun isIndoorLevelPickerEnabled(): Boolean {
+    return getMap().uiSettings.isIndoorLevelPickerEnabled
+  }
+
+  fun setIndoorLevelPickerEnabled(enabled: Boolean) {
+    getMap().uiSettings.isIndoorLevelPickerEnabled = enabled
+  }
+
   fun resetMinMaxZoomPreference() {
     _minZoomLevelPreference = null
     _maxZoomLevelPreference = null
@@ -547,6 +577,34 @@ abstract class GoogleMapsBaseMapView(
 
   fun setBuildingsEnabled(enabled: Boolean) {
     getMap().isBuildingsEnabled = enabled
+  }
+
+  fun isIndoorEnabled(): Boolean {
+    return getMap().isIndoorEnabled
+  }
+
+  fun setIndoorEnabled(enabled: Boolean) {
+    getMap().isIndoorEnabled = enabled
+  }
+
+  fun getFocusedIndoorBuilding(): IndoorBuildingDto? {
+    return getMap().focusedBuilding?.let { Convert.convertIndoorBuildingToDto(it) }
+  }
+
+  fun activateIndoorLevel(levelIndex: Int) {
+    val building =
+      getMap().focusedBuilding
+        ?: throw FlutterError(
+          "indoorLevelActivationFailed",
+          "No indoor building is currently focused",
+        )
+    if (levelIndex < 0 || levelIndex >= building.levels.size) {
+      throw FlutterError(
+        "indoorLevelActivationFailed",
+        "Level index $levelIndex is out of range (building has ${building.levels.size} levels)",
+      )
+    }
+    building.levels[levelIndex].activate()
   }
 
   fun getMyLocation(): Location? {

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsViewMessageHandler.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsViewMessageHandler.kt
@@ -384,6 +384,30 @@ class GoogleMapsViewMessageHandler(private val viewRegistry: GoogleMapsViewRegis
     getView(viewId.toInt()).setBuildingsEnabled(enabled)
   }
 
+  override fun isIndoorEnabled(viewId: Long): Boolean {
+    return getView(viewId.toInt()).isIndoorEnabled()
+  }
+
+  override fun setIndoorEnabled(viewId: Long, enabled: Boolean) {
+    getView(viewId.toInt()).setIndoorEnabled(enabled)
+  }
+
+  override fun isIndoorLevelPickerEnabled(viewId: Long): Boolean {
+    return getView(viewId.toInt()).isIndoorLevelPickerEnabled()
+  }
+
+  override fun setIndoorLevelPickerEnabled(viewId: Long, enabled: Boolean) {
+    getView(viewId.toInt()).setIndoorLevelPickerEnabled(enabled)
+  }
+
+  override fun getFocusedIndoorBuilding(viewId: Long): IndoorBuildingDto? {
+    return getView(viewId.toInt()).getFocusedIndoorBuilding()
+  }
+
+  override fun activateIndoorLevel(viewId: Long, levelIndex: Long) {
+    getView(viewId.toInt()).activateIndoorLevel(levelIndex.toInt())
+  }
+
   override fun isTrafficPromptsEnabled(viewId: Long): Boolean {
     return getNavigationView(viewId.toInt()).isTrafficPromptsEnabled()
   }

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/messages.g.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/messages.g.kt
@@ -8038,13 +8038,13 @@ interface AutoMapViewApi {
 
   fun isNavigationUIEnabled(): Boolean
 
-  fun isIndoorEnabled(viewId: Long): Boolean
+  fun isIndoorEnabled(): Boolean
 
-  fun setIndoorEnabled(viewId: Long, enabled: Boolean)
+  fun setIndoorEnabled(enabled: Boolean)
 
-  fun getFocusedIndoorBuilding(viewId: Long): IndoorBuildingDto?
+  fun getFocusedIndoorBuilding(): IndoorBuildingDto?
 
-  fun activateIndoorLevel(viewId: Long, levelIndex: Long)
+  fun activateIndoorLevel(levelIndex: Long)
 
   fun showRouteOverview()
 
@@ -9597,12 +9597,10 @@ interface AutoMapViewApi {
             codec,
           )
         if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val viewIdArg = args[0] as Long
+          channel.setMessageHandler { _, reply ->
             val wrapped: List<Any?> =
               try {
-                listOf(api.isIndoorEnabled(viewIdArg))
+                listOf(api.isIndoorEnabled())
               } catch (exception: Throwable) {
                 MessagesPigeonUtils.wrapError(exception)
               }
@@ -9622,11 +9620,10 @@ interface AutoMapViewApi {
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val viewIdArg = args[0] as Long
-            val enabledArg = args[1] as Boolean
+            val enabledArg = args[0] as Boolean
             val wrapped: List<Any?> =
               try {
-                api.setIndoorEnabled(viewIdArg, enabledArg)
+                api.setIndoorEnabled(enabledArg)
                 listOf(null)
               } catch (exception: Throwable) {
                 MessagesPigeonUtils.wrapError(exception)
@@ -9645,12 +9642,10 @@ interface AutoMapViewApi {
             codec,
           )
         if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val viewIdArg = args[0] as Long
+          channel.setMessageHandler { _, reply ->
             val wrapped: List<Any?> =
               try {
-                listOf(api.getFocusedIndoorBuilding(viewIdArg))
+                listOf(api.getFocusedIndoorBuilding())
               } catch (exception: Throwable) {
                 MessagesPigeonUtils.wrapError(exception)
               }
@@ -9670,11 +9665,10 @@ interface AutoMapViewApi {
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val viewIdArg = args[0] as Long
-            val levelIndexArg = args[1] as Long
+            val levelIndexArg = args[0] as Long
             val wrapped: List<Any?> =
               try {
-                api.activateIndoorLevel(viewIdArg, levelIndexArg)
+                api.activateIndoorLevel(levelIndexArg)
                 listOf(null)
               } catch (exception: Throwable) {
                 MessagesPigeonUtils.wrapError(exception)

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/messages.g.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/messages.g.kt
@@ -1147,6 +1147,84 @@ data class PointOfInterestDto(
   override fun hashCode(): Int = toList().hashCode()
 }
 
+/**
+ * Represents one indoor level of a focused indoor building.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class IndoorLevelDto(
+  /** Full display name of the level. */
+  val name: String? = null,
+  /** Short display name of the level. */
+  val shortName: String? = null,
+) {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): IndoorLevelDto {
+      val name = pigeonVar_list[0] as String?
+      val shortName = pigeonVar_list[1] as String?
+      return IndoorLevelDto(name, shortName)
+    }
+  }
+
+  fun toList(): List<Any?> {
+    return listOf(name, shortName)
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (other !is IndoorLevelDto) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return MessagesPigeonUtils.deepEquals(toList(), other.toList())
+  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
+/**
+ * Represents focused indoor building metadata.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class IndoorBuildingDto(
+  /** All levels available in the focused building. */
+  val levels: List<IndoorLevelDto?>,
+  /** Currently active level index in [levels], if known. */
+  val activeLevelIndex: Long? = null,
+  /** Default level index in [levels], if known. */
+  val defaultLevelIndex: Long? = null,
+  /** Whether building is mostly underground, if known. */
+  val isUnderground: Boolean? = null,
+) {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): IndoorBuildingDto {
+      val levels = pigeonVar_list[0] as List<IndoorLevelDto?>
+      val activeLevelIndex = pigeonVar_list[1] as Long?
+      val defaultLevelIndex = pigeonVar_list[2] as Long?
+      val isUnderground = pigeonVar_list[3] as Boolean?
+      return IndoorBuildingDto(levels, activeLevelIndex, defaultLevelIndex, isUnderground)
+    }
+  }
+
+  fun toList(): List<Any?> {
+    return listOf(levels, activeLevelIndex, defaultLevelIndex, isUnderground)
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (other !is IndoorBuildingDto) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return MessagesPigeonUtils.deepEquals(toList(), other.toList())
+  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
 /** Generated class from Pigeon that represents data sent in messages. */
 data class PolygonDto(val polygonId: String, val options: PolygonOptionsDto) {
   companion object {
@@ -2668,120 +2746,126 @@ private open class messagesPigeonCodec : StandardMessageCodec() {
         return (readValue(buffer) as? List<Any?>)?.let { PointOfInterestDto.fromList(it) }
       }
       166.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { PolygonDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { IndoorLevelDto.fromList(it) }
       }
       167.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { PolygonOptionsDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { IndoorBuildingDto.fromList(it) }
       }
       168.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { PolygonHoleDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { PolygonDto.fromList(it) }
       }
       169.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { StyleSpanStrokeStyleDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { PolygonOptionsDto.fromList(it) }
       }
       170.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { StyleSpanDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { PolygonHoleDto.fromList(it) }
       }
       171.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { PolylineDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { StyleSpanStrokeStyleDto.fromList(it) }
       }
       172.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { PatternItemDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { StyleSpanDto.fromList(it) }
       }
       173.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { PolylineOptionsDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { PolylineDto.fromList(it) }
       }
       174.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { CircleDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { PatternItemDto.fromList(it) }
       }
       175.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { CircleOptionsDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { PolylineOptionsDto.fromList(it) }
       }
       176.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { MapPaddingDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { CircleDto.fromList(it) }
       }
       177.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { RouteTokenOptionsDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { CircleOptionsDto.fromList(it) }
       }
       178.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { DestinationsDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { MapPaddingDto.fromList(it) }
       }
       179.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { RoutingOptionsDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { RouteTokenOptionsDto.fromList(it) }
       }
       180.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { NavigationDisplayOptionsDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { DestinationsDto.fromList(it) }
       }
       181.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let { NavigationWaypointDto.fromList(it) }
+        return (readValue(buffer) as? List<Any?>)?.let { RoutingOptionsDto.fromList(it) }
       }
       182.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let { NavigationDisplayOptionsDto.fromList(it) }
+      }
+      183.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let { NavigationWaypointDto.fromList(it) }
+      }
+      184.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           ContinueToNextDestinationResponseDto.fromList(it)
         }
       }
-      183.toByte() -> {
+      185.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { NavigationTimeAndDistanceDto.fromList(it) }
       }
-      184.toByte() -> {
+      186.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           NavigationAudioGuidanceSettingsDto.fromList(it)
         }
       }
-      185.toByte() -> {
+      187.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { SimulationOptionsDto.fromList(it) }
       }
-      186.toByte() -> {
+      188.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { LatLngDto.fromList(it) }
       }
-      187.toByte() -> {
+      189.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { LatLngBoundsDto.fromList(it) }
       }
-      188.toByte() -> {
+      190.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { SpeedingUpdatedEventDto.fromList(it) }
       }
-      189.toByte() -> {
+      191.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           GpsAvailabilityChangeEventDto.fromList(it)
         }
       }
-      190.toByte() -> {
+      192.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           SpeedAlertOptionsThresholdPercentageDto.fromList(it)
         }
       }
-      191.toByte() -> {
+      193.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { SpeedAlertOptionsDto.fromList(it) }
       }
-      192.toByte() -> {
+      194.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           RouteSegmentTrafficDataRoadStretchRenderingDataDto.fromList(it)
         }
       }
-      193.toByte() -> {
+      195.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { RouteSegmentTrafficDataDto.fromList(it) }
       }
-      194.toByte() -> {
+      196.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { RouteSegmentDto.fromList(it) }
       }
-      195.toByte() -> {
+      197.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { LaneDirectionDto.fromList(it) }
       }
-      196.toByte() -> {
+      198.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { LaneDto.fromList(it) }
       }
-      197.toByte() -> {
+      199.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { StepInfoDto.fromList(it) }
       }
-      198.toByte() -> {
+      200.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { NavInfoDto.fromList(it) }
       }
-      199.toByte() -> {
+      201.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           TermsAndConditionsUIParamsDto.fromList(it)
         }
       }
-      200.toByte() -> {
+      202.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           StepImageGenerationOptionsDto.fromList(it)
         }
@@ -2940,144 +3024,152 @@ private open class messagesPigeonCodec : StandardMessageCodec() {
         stream.write(165)
         writeValue(stream, value.toList())
       }
-      is PolygonDto -> {
+      is IndoorLevelDto -> {
         stream.write(166)
         writeValue(stream, value.toList())
       }
-      is PolygonOptionsDto -> {
+      is IndoorBuildingDto -> {
         stream.write(167)
         writeValue(stream, value.toList())
       }
-      is PolygonHoleDto -> {
+      is PolygonDto -> {
         stream.write(168)
         writeValue(stream, value.toList())
       }
-      is StyleSpanStrokeStyleDto -> {
+      is PolygonOptionsDto -> {
         stream.write(169)
         writeValue(stream, value.toList())
       }
-      is StyleSpanDto -> {
+      is PolygonHoleDto -> {
         stream.write(170)
         writeValue(stream, value.toList())
       }
-      is PolylineDto -> {
+      is StyleSpanStrokeStyleDto -> {
         stream.write(171)
         writeValue(stream, value.toList())
       }
-      is PatternItemDto -> {
+      is StyleSpanDto -> {
         stream.write(172)
         writeValue(stream, value.toList())
       }
-      is PolylineOptionsDto -> {
+      is PolylineDto -> {
         stream.write(173)
         writeValue(stream, value.toList())
       }
-      is CircleDto -> {
+      is PatternItemDto -> {
         stream.write(174)
         writeValue(stream, value.toList())
       }
-      is CircleOptionsDto -> {
+      is PolylineOptionsDto -> {
         stream.write(175)
         writeValue(stream, value.toList())
       }
-      is MapPaddingDto -> {
+      is CircleDto -> {
         stream.write(176)
         writeValue(stream, value.toList())
       }
-      is RouteTokenOptionsDto -> {
+      is CircleOptionsDto -> {
         stream.write(177)
         writeValue(stream, value.toList())
       }
-      is DestinationsDto -> {
+      is MapPaddingDto -> {
         stream.write(178)
         writeValue(stream, value.toList())
       }
-      is RoutingOptionsDto -> {
+      is RouteTokenOptionsDto -> {
         stream.write(179)
         writeValue(stream, value.toList())
       }
-      is NavigationDisplayOptionsDto -> {
+      is DestinationsDto -> {
         stream.write(180)
         writeValue(stream, value.toList())
       }
-      is NavigationWaypointDto -> {
+      is RoutingOptionsDto -> {
         stream.write(181)
         writeValue(stream, value.toList())
       }
-      is ContinueToNextDestinationResponseDto -> {
+      is NavigationDisplayOptionsDto -> {
         stream.write(182)
         writeValue(stream, value.toList())
       }
-      is NavigationTimeAndDistanceDto -> {
+      is NavigationWaypointDto -> {
         stream.write(183)
         writeValue(stream, value.toList())
       }
-      is NavigationAudioGuidanceSettingsDto -> {
+      is ContinueToNextDestinationResponseDto -> {
         stream.write(184)
         writeValue(stream, value.toList())
       }
-      is SimulationOptionsDto -> {
+      is NavigationTimeAndDistanceDto -> {
         stream.write(185)
         writeValue(stream, value.toList())
       }
-      is LatLngDto -> {
+      is NavigationAudioGuidanceSettingsDto -> {
         stream.write(186)
         writeValue(stream, value.toList())
       }
-      is LatLngBoundsDto -> {
+      is SimulationOptionsDto -> {
         stream.write(187)
         writeValue(stream, value.toList())
       }
-      is SpeedingUpdatedEventDto -> {
+      is LatLngDto -> {
         stream.write(188)
         writeValue(stream, value.toList())
       }
-      is GpsAvailabilityChangeEventDto -> {
+      is LatLngBoundsDto -> {
         stream.write(189)
         writeValue(stream, value.toList())
       }
-      is SpeedAlertOptionsThresholdPercentageDto -> {
+      is SpeedingUpdatedEventDto -> {
         stream.write(190)
         writeValue(stream, value.toList())
       }
-      is SpeedAlertOptionsDto -> {
+      is GpsAvailabilityChangeEventDto -> {
         stream.write(191)
         writeValue(stream, value.toList())
       }
-      is RouteSegmentTrafficDataRoadStretchRenderingDataDto -> {
+      is SpeedAlertOptionsThresholdPercentageDto -> {
         stream.write(192)
         writeValue(stream, value.toList())
       }
-      is RouteSegmentTrafficDataDto -> {
+      is SpeedAlertOptionsDto -> {
         stream.write(193)
         writeValue(stream, value.toList())
       }
-      is RouteSegmentDto -> {
+      is RouteSegmentTrafficDataRoadStretchRenderingDataDto -> {
         stream.write(194)
         writeValue(stream, value.toList())
       }
-      is LaneDirectionDto -> {
+      is RouteSegmentTrafficDataDto -> {
         stream.write(195)
         writeValue(stream, value.toList())
       }
-      is LaneDto -> {
+      is RouteSegmentDto -> {
         stream.write(196)
         writeValue(stream, value.toList())
       }
-      is StepInfoDto -> {
+      is LaneDirectionDto -> {
         stream.write(197)
         writeValue(stream, value.toList())
       }
-      is NavInfoDto -> {
+      is LaneDto -> {
         stream.write(198)
         writeValue(stream, value.toList())
       }
-      is TermsAndConditionsUIParamsDto -> {
+      is StepInfoDto -> {
         stream.write(199)
         writeValue(stream, value.toList())
       }
-      is StepImageGenerationOptionsDto -> {
+      is NavInfoDto -> {
         stream.write(200)
+        writeValue(stream, value.toList())
+      }
+      is TermsAndConditionsUIParamsDto -> {
+        stream.write(201)
+        writeValue(stream, value.toList())
+      }
+      is StepImageGenerationOptionsDto -> {
+        stream.write(202)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)
@@ -3247,6 +3339,22 @@ interface MapViewApi {
   fun isBuildingsEnabled(viewId: Long): Boolean
 
   fun setBuildingsEnabled(viewId: Long, enabled: Boolean)
+
+  fun isIndoorEnabled(viewId: Long): Boolean
+
+  fun setIndoorEnabled(viewId: Long, enabled: Boolean)
+
+  fun isIndoorLevelPickerEnabled(viewId: Long): Boolean
+
+  fun setIndoorLevelPickerEnabled(viewId: Long, enabled: Boolean)
+
+  fun getFocusedIndoorBuilding(viewId: Long): IndoorBuildingDto?
+
+  /**
+   * Activates the indoor level at [levelIndex] within the currently focused indoor building. Throws
+   * if no building is focused or the index is out of range.
+   */
+  fun activateIndoorLevel(viewId: Long, levelIndex: Long)
 
   fun getCameraPosition(viewId: Long): CameraPositionDto
 
@@ -4664,6 +4772,150 @@ interface MapViewApi {
             val wrapped: List<Any?> =
               try {
                 api.setBuildingsEnabled(viewIdArg, enabledArg)
+                listOf(null)
+              } catch (exception: Throwable) {
+                MessagesPigeonUtils.wrapError(exception)
+              }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+          BasicMessageChannel<Any?>(
+            binaryMessenger,
+            "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorEnabled$separatedMessageChannelSuffix",
+            codec,
+          )
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val viewIdArg = args[0] as Long
+            val wrapped: List<Any?> =
+              try {
+                listOf(api.isIndoorEnabled(viewIdArg))
+              } catch (exception: Throwable) {
+                MessagesPigeonUtils.wrapError(exception)
+              }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+          BasicMessageChannel<Any?>(
+            binaryMessenger,
+            "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorEnabled$separatedMessageChannelSuffix",
+            codec,
+          )
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val viewIdArg = args[0] as Long
+            val enabledArg = args[1] as Boolean
+            val wrapped: List<Any?> =
+              try {
+                api.setIndoorEnabled(viewIdArg, enabledArg)
+                listOf(null)
+              } catch (exception: Throwable) {
+                MessagesPigeonUtils.wrapError(exception)
+              }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+          BasicMessageChannel<Any?>(
+            binaryMessenger,
+            "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorLevelPickerEnabled$separatedMessageChannelSuffix",
+            codec,
+          )
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val viewIdArg = args[0] as Long
+            val wrapped: List<Any?> =
+              try {
+                listOf(api.isIndoorLevelPickerEnabled(viewIdArg))
+              } catch (exception: Throwable) {
+                MessagesPigeonUtils.wrapError(exception)
+              }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+          BasicMessageChannel<Any?>(
+            binaryMessenger,
+            "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorLevelPickerEnabled$separatedMessageChannelSuffix",
+            codec,
+          )
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val viewIdArg = args[0] as Long
+            val enabledArg = args[1] as Boolean
+            val wrapped: List<Any?> =
+              try {
+                api.setIndoorLevelPickerEnabled(viewIdArg, enabledArg)
+                listOf(null)
+              } catch (exception: Throwable) {
+                MessagesPigeonUtils.wrapError(exception)
+              }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+          BasicMessageChannel<Any?>(
+            binaryMessenger,
+            "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.getFocusedIndoorBuilding$separatedMessageChannelSuffix",
+            codec,
+          )
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val viewIdArg = args[0] as Long
+            val wrapped: List<Any?> =
+              try {
+                listOf(api.getFocusedIndoorBuilding(viewIdArg))
+              } catch (exception: Throwable) {
+                MessagesPigeonUtils.wrapError(exception)
+              }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+          BasicMessageChannel<Any?>(
+            binaryMessenger,
+            "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.activateIndoorLevel$separatedMessageChannelSuffix",
+            codec,
+          )
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val viewIdArg = args[0] as Long
+            val levelIndexArg = args[1] as Long
+            val wrapped: List<Any?> =
+              try {
+                api.activateIndoorLevel(viewIdArg, levelIndexArg)
                 listOf(null)
               } catch (exception: Throwable) {
                 MessagesPigeonUtils.wrapError(exception)
@@ -6389,6 +6641,52 @@ class ViewEventApi(
     }
   }
 
+  fun onIndoorFocusedBuildingChanged(
+    viewIdArg: Long,
+    buildingArg: IndoorBuildingDto?,
+    callback: (Result<Unit>) -> Unit,
+  ) {
+    val separatedMessageChannelSuffix =
+      if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName =
+      "dev.flutter.pigeon.google_navigation_flutter.ViewEventApi.onIndoorFocusedBuildingChanged$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(viewIdArg, buildingArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(MessagesPigeonUtils.createConnectionError(channelName)))
+      }
+    }
+  }
+
+  fun onIndoorActiveLevelChanged(
+    viewIdArg: Long,
+    buildingArg: IndoorBuildingDto?,
+    callback: (Result<Unit>) -> Unit,
+  ) {
+    val separatedMessageChannelSuffix =
+      if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName =
+      "dev.flutter.pigeon.google_navigation_flutter.ViewEventApi.onIndoorActiveLevelChanged$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(viewIdArg, buildingArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(MessagesPigeonUtils.createConnectionError(channelName)))
+      }
+    }
+  }
+
   fun onCameraChanged(
     viewIdArg: Long,
     eventTypeArg: CameraEventTypeDto,
@@ -7739,6 +8037,14 @@ interface AutoMapViewApi {
   fun isSpeedometerEnabled(): Boolean
 
   fun isNavigationUIEnabled(): Boolean
+
+  fun isIndoorEnabled(viewId: Long): Boolean
+
+  fun setIndoorEnabled(viewId: Long, enabled: Boolean)
+
+  fun getFocusedIndoorBuilding(viewId: Long): IndoorBuildingDto?
+
+  fun activateIndoorLevel(viewId: Long, levelIndex: Long)
 
   fun showRouteOverview()
 
@@ -9287,6 +9593,102 @@ interface AutoMapViewApi {
         val channel =
           BasicMessageChannel<Any?>(
             binaryMessenger,
+            "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isIndoorEnabled$separatedMessageChannelSuffix",
+            codec,
+          )
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val viewIdArg = args[0] as Long
+            val wrapped: List<Any?> =
+              try {
+                listOf(api.isIndoorEnabled(viewIdArg))
+              } catch (exception: Throwable) {
+                MessagesPigeonUtils.wrapError(exception)
+              }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+          BasicMessageChannel<Any?>(
+            binaryMessenger,
+            "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled$separatedMessageChannelSuffix",
+            codec,
+          )
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val viewIdArg = args[0] as Long
+            val enabledArg = args[1] as Boolean
+            val wrapped: List<Any?> =
+              try {
+                api.setIndoorEnabled(viewIdArg, enabledArg)
+                listOf(null)
+              } catch (exception: Throwable) {
+                MessagesPigeonUtils.wrapError(exception)
+              }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+          BasicMessageChannel<Any?>(
+            binaryMessenger,
+            "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.getFocusedIndoorBuilding$separatedMessageChannelSuffix",
+            codec,
+          )
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val viewIdArg = args[0] as Long
+            val wrapped: List<Any?> =
+              try {
+                listOf(api.getFocusedIndoorBuilding(viewIdArg))
+              } catch (exception: Throwable) {
+                MessagesPigeonUtils.wrapError(exception)
+              }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+          BasicMessageChannel<Any?>(
+            binaryMessenger,
+            "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel$separatedMessageChannelSuffix",
+            codec,
+          )
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val viewIdArg = args[0] as Long
+            val levelIndexArg = args[1] as Long
+            val wrapped: List<Any?> =
+              try {
+                api.activateIndoorLevel(viewIdArg, levelIndexArg)
+                listOf(null)
+              } catch (exception: Throwable) {
+                MessagesPigeonUtils.wrapError(exception)
+              }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+          BasicMessageChannel<Any?>(
+            binaryMessenger,
             "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.showRouteOverview$separatedMessageChannelSuffix",
             codec,
           )
@@ -10045,6 +10447,50 @@ class AutoViewEventApi(
       "dev.flutter.pigeon.google_navigation_flutter.AutoViewEventApi.onPromptVisibilityChanged$separatedMessageChannelSuffix"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(promptVisibleArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(MessagesPigeonUtils.createConnectionError(channelName)))
+      }
+    }
+  }
+
+  fun onIndoorFocusedBuildingChanged(
+    buildingArg: IndoorBuildingDto?,
+    callback: (Result<Unit>) -> Unit,
+  ) {
+    val separatedMessageChannelSuffix =
+      if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName =
+      "dev.flutter.pigeon.google_navigation_flutter.AutoViewEventApi.onIndoorFocusedBuildingChanged$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(buildingArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(MessagesPigeonUtils.createConnectionError(channelName)))
+      }
+    }
+  }
+
+  fun onIndoorActiveLevelChanged(
+    buildingArg: IndoorBuildingDto?,
+    callback: (Result<Unit>) -> Unit,
+  ) {
+    val separatedMessageChannelSuffix =
+      if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName =
+      "dev.flutter.pigeon.google_navigation_flutter.AutoViewEventApi.onIndoorActiveLevelChanged$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(buildingArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
           callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))

--- a/example/lib/pages/map.dart
+++ b/example/lib/pages/map.dart
@@ -49,6 +49,9 @@ class _MapPageState extends ExamplePageState<BasicMapPage> {
   bool isScrollGesturesEnabledDuringRotateOrZoom = true;
   bool isTiltGesturesEnabled = true;
   bool isTrafficEnabled = false;
+  bool isIndoorEnabled = true;
+  bool isIndoorLevelPickerEnabled = true;
+  IndoorBuilding? _focusedIndoorBuilding;
   MapType mapType = MapType.normal;
   MapColorScheme mapColorScheme = MapColorScheme.followSystem;
 
@@ -129,6 +132,32 @@ class _MapPageState extends ExamplePageState<BasicMapPage> {
     _showMessage('My location button clicked');
   }
 
+  void _onIndoorFocusedBuildingChanged(IndoorBuilding? building) {
+    setState(() {
+      _focusedIndoorBuilding = building;
+    });
+    final String msg = building == null
+        ? 'Indoor focus lost'
+        : 'Focused building: ${building.levels.length} level(s), '
+              'active: ${building.activeLevelIndex}';
+    _showMessage(msg);
+  }
+
+  void _onIndoorActiveLevelChanged(IndoorBuilding? building) {
+    setState(() {
+      _focusedIndoorBuilding = building;
+    });
+    final int? active = building?.activeLevelIndex;
+    final String levelName =
+        (active != null &&
+            building != null &&
+            active >= 0 &&
+            active < building.levels.length)
+        ? (building.levels[active].name ?? 'Level $active')
+        : 'none';
+    _showMessage('Active indoor level: $levelName');
+  }
+
   @override
   Widget build(BuildContext context) {
     final ButtonStyle mapTypeStyle = ElevatedButton.styleFrom(
@@ -144,6 +173,8 @@ class _MapPageState extends ExamplePageState<BasicMapPage> {
             onViewCreated: _onViewCreated,
             onMyLocationClicked: _onMyLocationClicked,
             onMyLocationButtonClicked: _onMyLocationButtonClicked,
+            onIndoorFocusedBuildingChanged: _onIndoorFocusedBuildingChanged,
+            onIndoorActiveLevelChanged: _onIndoorActiveLevelChanged,
             mapId: MapIdManager.instance.mapId,
           ),
           Padding(
@@ -422,6 +453,74 @@ class _MapPageState extends ExamplePageState<BasicMapPage> {
           title: const Text('Enable traffic'),
           value: isTrafficEnabled,
         ),
+        SwitchListTile(
+          onChanged: (bool newValue) async {
+            await _mapViewController.setIndoorEnabled(newValue);
+            setState(() {
+              isIndoorEnabled = newValue;
+              if (!newValue) {
+                _focusedIndoorBuilding = null;
+              }
+            });
+          },
+          title: const Text('Enable indoor maps'),
+          value: isIndoorEnabled,
+        ),
+        SwitchListTile(
+          onChanged: isIndoorEnabled
+              ? (bool newValue) async {
+                  await _mapViewController.settings.setIndoorLevelPickerEnabled(
+                    newValue,
+                  );
+                  setState(() {
+                    isIndoorLevelPickerEnabled = newValue;
+                  });
+                }
+              : null,
+          title: const Text('Show indoor level picker'),
+          value: isIndoorLevelPickerEnabled,
+        ),
+        if (_focusedIndoorBuilding != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Focused building: '
+                  '${_focusedIndoorBuilding!.levels.length} level(s)',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                if (Platform.isAndroid)
+                  Wrap(
+                    spacing: 6,
+                    children: <Widget>[
+                      for (final IndoorLevel level
+                          in _focusedIndoorBuilding!.levels)
+                        ActionChip(
+                          label: Text(
+                            level.shortName ?? 'L${level.levelIndex}',
+                          ),
+                          backgroundColor:
+                              _focusedIndoorBuilding!.activeLevelIndex ==
+                                  level.levelIndex
+                              ? Theme.of(context).colorScheme.primaryContainer
+                              : null,
+                          onPressed: () async {
+                            try {
+                              await _mapViewController.activateIndoorLevel(
+                                level,
+                              );
+                            } catch (e) {
+                              _showMessage('Failed to activate level: $e');
+                            }
+                          },
+                        ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
         const Divider(),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/example/lib/pages/navigation.dart
+++ b/example/lib/pages/navigation.dart
@@ -174,10 +174,6 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
   _roadSnappedRawLocationUpdatedSubscription;
   StreamSubscription<void>? _newNavigationSessionSubscription;
 
-  // Indoor event subscriptions are set up via widget-level callbacks
-  // (onIndoorFocusedBuildingChanged / onIndoorActiveLevelChanged) and
-  // do not need separate StreamSubscription fields here.
-
   int _nextWaypointIndex = 0;
 
   /// Track when user has arrived at a waypoint but hasn't continued yet

--- a/example/lib/pages/navigation.dart
+++ b/example/lib/pages/navigation.dart
@@ -101,6 +101,10 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
   int _onNavigationUIEnabledChangedEventCallCount = 0;
   int _onNewNavigationSessionEventCallCount = 0;
   int _onPromptVisibilityChangedEventCallCount = 0;
+  int _onIndoorFocusedBuildingChangedEventCallCount = 0;
+  int _onIndoorActiveLevelChangedEventCallCount = 0;
+
+  IndoorBuilding? _focusedIndoorBuilding;
 
   bool _navigationHeaderEnabled = true;
   bool _navigationFooterEnabled = true;
@@ -113,6 +117,8 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
   bool _trafficPromptsEnabled = true;
   bool _reportIncidentButtonEnabled = true;
   bool _buildingsEnabled = true;
+  bool _indoorEnabled = true;
+  bool _indoorLevelPickerEnabled = true;
 
   bool _termsAndConditionsAccepted = false;
   bool _locationPermissionsAccepted = false;
@@ -167,6 +173,10 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
   StreamSubscription<RoadSnappedRawLocationUpdatedEvent>?
   _roadSnappedRawLocationUpdatedSubscription;
   StreamSubscription<void>? _newNavigationSessionSubscription;
+
+  // Indoor event subscriptions are set up via widget-level callbacks
+  // (onIndoorFocusedBuildingChanged / onIndoorActiveLevelChanged) and
+  // do not need separate StreamSubscription fields here.
 
   int _nextWaypointIndex = 0;
 
@@ -657,6 +667,36 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
     });
   }
 
+  void _onIndoorFocusedBuildingChanged(IndoorBuilding? building) {
+    if (!mounted) return;
+    setState(() {
+      _focusedIndoorBuilding = building;
+      _onIndoorFocusedBuildingChangedEventCallCount += 1;
+    });
+    final String msg = building == null
+        ? 'Indoor focus lost'
+        : 'Focused building: ${building.levels.length} level(s), '
+              'active index: ${building.activeLevelIndex}';
+    debugPrint('Indoor focused building changed: $msg');
+  }
+
+  void _onIndoorActiveLevelChanged(IndoorBuilding? building) {
+    if (!mounted) return;
+    setState(() {
+      _focusedIndoorBuilding = building;
+      _onIndoorActiveLevelChangedEventCallCount += 1;
+    });
+    final int? active = building?.activeLevelIndex;
+    final String levelName =
+        (active != null &&
+            building != null &&
+            active >= 0 &&
+            active < building.levels.length)
+        ? (building.levels[active].name ?? 'unknown')
+        : 'none';
+    debugPrint('Indoor active level changed: $levelName');
+  }
+
   Future<void> _onViewCreated(GoogleNavigationViewController controller) async {
     setState(() {
       _navigationViewController = controller;
@@ -722,6 +762,11 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
           .isReportIncidentButtonEnabled();
       final bool buildingsEnabled = await _navigationViewController!
           .isBuildingsEnabled();
+      final bool indoorEnabled = await _navigationViewController!
+          .isIndoorEnabled();
+      final bool indoorLevelPickerEnabled = await _navigationViewController!
+          .settings
+          .isIndoorLevelPickerEnabled();
 
       setState(() {
         _navigationHeaderEnabled = navigationHeaderEnabled;
@@ -735,6 +780,8 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
         _trafficPromptsEnabled = trafficPromptsEnabled;
         _reportIncidentButtonEnabled = reportIncidentButtonEnabled;
         _buildingsEnabled = buildingsEnabled;
+        _indoorEnabled = indoorEnabled;
+        _indoorLevelPickerEnabled = indoorLevelPickerEnabled;
       });
     }
   }
@@ -938,15 +985,19 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
       final String waypointTitle = _lastClickedPoi != null
           ? '${_lastClickedPoi!.name} (Waypoint $_nextWaypointIndex)'
           : 'Waypoint $_nextWaypointIndex';
-      _waypoints.add(
-        NavigationWaypoint.withLatLngTarget(
-          title: waypointTitle,
-          target: LatLng(
-            latitude: _newWaypointMarker!.options.position.latitude,
-            longitude: _newWaypointMarker!.options.position.longitude,
-          ),
-        ),
-      );
+      final NavigationWaypoint waypoint = _lastClickedPoi != null
+          ? NavigationWaypoint.withPlaceID(
+              title: waypointTitle,
+              placeID: _lastClickedPoi!.placeID,
+            )
+          : NavigationWaypoint.withLatLngTarget(
+              title: waypointTitle,
+              target: LatLng(
+                latitude: _newWaypointMarker!.options.position.latitude,
+                longitude: _newWaypointMarker!.options.position.longitude,
+              ),
+            );
+      _waypoints.add(waypoint);
 
       // Convert new waypoint marker to destination marker.
       await _convertNewWaypointMarkerToDestinationMarker(_nextWaypointIndex);
@@ -1330,6 +1381,35 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
     }
   }
 
+  Future<void> _simulateUserLocationToCurrentCamera() async {
+    if (_navigationViewController == null) {
+      _showMessage('Navigation view is not ready yet.');
+      return;
+    }
+
+    if (!_navigatorInitialized) {
+      await _initializeNavigator();
+      if (!_navigatorInitialized) {
+        _showMessage(
+          'Navigation session could not be initialized for simulation.',
+        );
+        return;
+      }
+    }
+
+    final LatLng cameraTarget =
+        (await _navigationViewController!.getCameraPosition()).target;
+    await _simulateStationaryUserLocation(cameraTarget);
+
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _userLocation = cameraTarget;
+    });
+    _showMessage('Simulated user location to current camera location.');
+  }
+
   Future<void> _simulateStationaryUserLocation(LatLng? location) async {
     if (location == null) {
       return;
@@ -1432,6 +1512,9 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
                         onNavigationUIEnabledChanged:
                             _onNavigationUIEnabledChanged,
                         onPromptVisibilityChanged: _onPromptVisibilityChanged,
+                        onIndoorFocusedBuildingChanged:
+                            _onIndoorFocusedBuildingChanged,
+                        onIndoorActiveLevelChanged: _onIndoorActiveLevelChanged,
                         initialCameraPosition: CameraPosition(
                           // Initialize map to user location.
                           target: _userLocation!,
@@ -1744,6 +1827,26 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
                   ),
                 ),
               ),
+              Card(
+                child: ListTile(
+                  title: const Text(
+                    'Indoor focused building changed event call count',
+                  ),
+                  trailing: Text(
+                    _onIndoorFocusedBuildingChangedEventCallCount.toString(),
+                  ),
+                ),
+              ),
+              Card(
+                child: ListTile(
+                  title: const Text(
+                    'Indoor active level changed event call count',
+                  ),
+                  trailing: Text(
+                    _onIndoorActiveLevelChangedEventCallCount.toString(),
+                  ),
+                ),
+              ),
             ],
           ),
         );
@@ -1878,39 +1981,42 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
             ],
           ),
         ),
-        IgnorePointer(
-          ignoring: !_navigatorInitialized,
-          child: Card(
-            child: ExpansionTile(
-              title: const Text('Simulation'),
-              collapsedTextColor: getExpansionTileTextColor(
-                !_navigatorInitialized,
+        Card(
+          child: ExpansionTile(
+            title: const Text('Simulation'),
+            children: <Widget>[
+              Wrap(
+                alignment: WrapAlignment.center,
+                spacing: 10,
+                children: <Widget>[
+                  if (_simulationState == SimulationState.running)
+                    ElevatedButton(
+                      onPressed: _pauseSimulation,
+                      child: const Text('Pause simulation'),
+                    )
+                  else if (_simulationState == SimulationState.paused)
+                    ElevatedButton(
+                      onPressed: _resumeSimulation,
+                      child: const Text('Resume simulation'),
+                    )
+                  else
+                    SizedBox(
+                      width: double.infinity,
+                      child: Text(
+                        _simulationState.description,
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ElevatedButton(
+                    onPressed: _navigationViewController == null
+                        ? null
+                        : _simulateUserLocationToCurrentCamera,
+                    child: const Text('Set user to camera'),
+                  ),
+                ],
               ),
-              collapsedIconColor: getExpansionTileTextColor(
-                !_navigatorInitialized,
-              ),
-              children: <Widget>[
-                Wrap(
-                  alignment: WrapAlignment.center,
-                  spacing: 10,
-                  children: <Widget>[
-                    if (_simulationState == SimulationState.running)
-                      ElevatedButton(
-                        onPressed: _pauseSimulation,
-                        child: const Text('Pause simulation'),
-                      )
-                    else if (_simulationState == SimulationState.paused)
-                      ElevatedButton(
-                        onPressed: _resumeSimulation,
-                        child: const Text('Resume simulation'),
-                      )
-                    else
-                      Text(_simulationState.description),
-                  ],
-                ),
-                const SizedBox(height: 10),
-              ],
-            ),
+              const SizedBox(height: 10),
+            ],
           ),
         ),
         IgnorePointer(
@@ -2054,6 +2160,81 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
                     });
                   },
                 ),
+                ExampleSwitch(
+                  title: 'Enable indoor maps',
+                  initialValue: _indoorEnabled,
+                  onChanged: (bool newValue) async {
+                    await _navigationViewController!.setIndoorEnabled(newValue);
+                    setState(() {
+                      _indoorEnabled = newValue;
+                    });
+                  },
+                ),
+                ExampleSwitch(
+                  title: 'Show indoor level picker',
+                  initialValue: _indoorLevelPickerEnabled,
+                  onChanged: (bool newValue) async {
+                    await _navigationViewController!.settings
+                        .setIndoorLevelPickerEnabled(newValue);
+                    setState(() {
+                      _indoorLevelPickerEnabled = newValue;
+                    });
+                  },
+                ),
+                if (_focusedIndoorBuilding != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 8,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          'Focused building: '
+                          '${_focusedIndoorBuilding!.levels.length} level(s)',
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                        Wrap(
+                          spacing: 6,
+                          children: <Widget>[
+                            for (final IndoorLevel level
+                                in _focusedIndoorBuilding!.levels)
+                              ActionChip(
+                                label: Text(
+                                  level.shortName ?? 'L${level.levelIndex}',
+                                ),
+                                backgroundColor:
+                                    _focusedIndoorBuilding!.activeLevelIndex ==
+                                        level.levelIndex
+                                    ? Theme.of(
+                                        context,
+                                      ).colorScheme.primaryContainer
+                                    : null,
+                                onPressed: () async {
+                                  try {
+                                    await _navigationViewController!
+                                        .activateIndoorLevel(level);
+                                  } catch (e) {
+                                    _showMessage(
+                                      'Failed to activate level: $e',
+                                    );
+                                  }
+                                },
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                if (_focusedIndoorBuilding == null && _indoorEnabled)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                    child: Text(
+                      'Navigate to an indoor area to see level controls.',
+                      style: TextStyle(color: Colors.grey),
+                    ),
+                  ),
                 Padding(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 16,

--- a/example/patrol_test/t04_navigation_ui_test.dart
+++ b/example/patrol_test/t04_navigation_ui_test.dart
@@ -278,6 +278,29 @@ void main() {
       );
     }
 
+    /// Test enabling and disabling indoor maps layer.
+    for (final bool result in results) {
+      await viewController.setIndoorEnabled(result);
+      final bool isEnabled = await viewController.isIndoorEnabled();
+      expect(
+        isEnabled,
+        result,
+        reason: buildReasonForToggle('IndoorEnabled', result),
+      );
+    }
+
+    /// Test enabling and disabling indoor level picker.
+    for (final bool result in results) {
+      await viewController.settings.setIndoorLevelPickerEnabled(result);
+      final bool isEnabled = await viewController.settings
+          .isIndoorLevelPickerEnabled();
+      expect(
+        isEnabled,
+        result,
+        reason: buildReasonForToggle('IndoorLevelPickerEnabled', result),
+      );
+    }
+
     /// Test map color scheme getter and setter.
     final List<MapColorScheme> mapColorSchemes = <MapColorScheme>[
       MapColorScheme.followSystem,

--- a/example/patrol_test/t06_map_test.dart
+++ b/example/patrol_test/t06_map_test.dart
@@ -78,6 +78,8 @@ void main() {
             initialZoomControlsEnabled: false,
             initialScrollGesturesEnabledDuringRotateOrZoom: false,
             initialMapToolbarEnabled: false,
+            initialIndoorEnabled: false,
+            initialIndoorLevelPickerEnabled: false,
             onViewCreated: (GoogleMapViewController viewController) {
               controllerCompleter.complete(viewController);
             },
@@ -99,6 +101,8 @@ void main() {
             initialZoomControlsEnabled: false,
             initialScrollGesturesEnabledDuringRotateOrZoom: false,
             initialMapToolbarEnabled: false,
+            initialIndoorEnabled: false,
+            initialIndoorLevelPickerEnabled: false,
             onViewCreated: (GoogleNavigationViewController viewController) {
               controllerCompleter.complete(viewController);
             },
@@ -120,6 +124,8 @@ void main() {
       await controller.settings.isScrollGesturesEnabledDuringRotateOrZoom(),
       false,
     );
+    expect(await controller.isIndoorEnabled(), false);
+    expect(await controller.settings.isIndoorLevelPickerEnabled(), false);
 
     if (Platform.isAndroid) {
       expect(await controller.settings.isZoomControlsEnabled(), false);
@@ -229,6 +235,8 @@ void main() {
       true,
     );
     expect(await controller.settings.isTiltGesturesEnabled(), true);
+    expect(await controller.isIndoorEnabled(), true);
+    expect(await controller.settings.isIndoorLevelPickerEnabled(), true);
     if (Platform.isAndroid) {
       expect(await controller.settings.isMapToolbarEnabled(), true);
     }
@@ -301,6 +309,20 @@ void main() {
         await controller.settings.isTrafficEnabled(),
         result,
         reason: buildReasonForToggle('TrafficEnabled', result),
+      );
+
+      await controller.setIndoorEnabled(result);
+      expect(
+        await controller.isIndoorEnabled(),
+        result,
+        reason: buildReasonForToggle('IndoorEnabled', result),
+      );
+
+      await controller.settings.setIndoorLevelPickerEnabled(result);
+      expect(
+        await controller.settings.isIndoorLevelPickerEnabled(),
+        result,
+        reason: buildReasonForToggle('IndoorLevelPickerEnabled', result),
       );
 
       if (Platform.isAndroid) {

--- a/example/patrol_test/t06_map_test.dart
+++ b/example/patrol_test/t06_map_test.dart
@@ -78,8 +78,6 @@ void main() {
             initialZoomControlsEnabled: false,
             initialScrollGesturesEnabledDuringRotateOrZoom: false,
             initialMapToolbarEnabled: false,
-            initialIndoorEnabled: false,
-            initialIndoorLevelPickerEnabled: false,
             onViewCreated: (GoogleMapViewController viewController) {
               controllerCompleter.complete(viewController);
             },
@@ -101,8 +99,6 @@ void main() {
             initialZoomControlsEnabled: false,
             initialScrollGesturesEnabledDuringRotateOrZoom: false,
             initialMapToolbarEnabled: false,
-            initialIndoorEnabled: false,
-            initialIndoorLevelPickerEnabled: false,
             onViewCreated: (GoogleNavigationViewController viewController) {
               controllerCompleter.complete(viewController);
             },
@@ -124,8 +120,6 @@ void main() {
       await controller.settings.isScrollGesturesEnabledDuringRotateOrZoom(),
       false,
     );
-    expect(await controller.isIndoorEnabled(), false);
-    expect(await controller.settings.isIndoorLevelPickerEnabled(), false);
 
     if (Platform.isAndroid) {
       expect(await controller.settings.isZoomControlsEnabled(), false);

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/BaseCarSceneDelegate.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/BaseCarSceneDelegate.swift
@@ -148,11 +148,22 @@ open class BaseCarSceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate
           self?.onPromptVisibilityChanged(promptVisible: promptVisible)
         }
 
+        self.navView?.indoorFocusedBuildingChangedCallback = { [weak self] building in
+          self?.sendIndoorFocusedBuildingChangedEvent(building: building)
+        }
+
+        self.navView?.indoorActiveLevelChangedCallback = { [weak self] building in
+          self?.sendIndoorActiveLevelChangedEvent(building: building)
+        }
+
         self.navView?.setNavigationHeaderEnabled(false)
         self.navView?.setRecenterButtonEnabled(false)
         self.navView?.setNavigationFooterEnabled(false)
         self.navView?.setSpeedometerEnabled(false)
         self.navView?.setReportIncidentButtonEnabled(false)
+        // Indoor level picker is not user-operable on CarPlay,
+        // so keep it disabled by default for car surfaces.
+        self.navView?.setIndoorLevelPickerEnabled(false)
         self.navViewController = UIViewController()
         self.navViewController?.view = self.navView?.view()
         self.carWindow?.rootViewController = self.navViewController
@@ -267,5 +278,14 @@ open class BaseCarSceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate
 
   func sendAutoScreenAvailabilityChangedEvent(isAvailable: Bool) {
     autoViewEventApi?.onAutoScreenAvailabilityChanged(isAvailable: isAvailable) { _ in }
+  }
+
+  func sendIndoorFocusedBuildingChangedEvent(building: IndoorBuildingDto?) {
+    autoViewEventApi?.onIndoorFocusedBuildingChanged(building: building) { _ in
+    }
+  }
+
+  func sendIndoorActiveLevelChangedEvent(building: IndoorBuildingDto?) {
+    autoViewEventApi?.onIndoorActiveLevelChanged(building: building) { _ in }
   }
 }

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/Convert.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/Convert.swift
@@ -137,6 +137,29 @@ enum Convert {
     LatLngDto(latitude: point.latitude, longitude: point.longitude)
   }
 
+  static func convertIndoorLevel(level: GMSIndoorLevel) -> IndoorLevelDto {
+    IndoorLevelDto(name: level.name, shortName: level.shortName)
+  }
+
+  static func convertIndoorBuilding(building: GMSIndoorBuilding, activeLevel: GMSIndoorLevel?)
+    -> IndoorBuildingDto
+  {
+    let levels = building.levels.map { convertIndoorLevel(level: $0) }
+    let activeLevelIndex: Int64? = {
+      guard let activeLevel else { return nil }
+      guard let index = building.levels.firstIndex(where: { $0 === activeLevel }) else {
+        return nil
+      }
+      return Int64(index)
+    }()
+    return IndoorBuildingDto(
+      levels: levels,
+      activeLevelIndex: activeLevelIndex,
+      defaultLevelIndex: Int64(building.defaultLevelIndex),
+      isUnderground: building.isUnderground
+    )
+  }
+
   static func convertLatLngBounds(bounds: LatLngBoundsDto) -> GMSCoordinateBounds {
     GMSCoordinateBounds(
       coordinate: CLLocationCoordinate2D(

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsAutoViewMessageHandler.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsAutoViewMessageHandler.swift
@@ -544,6 +544,22 @@ class GoogleMapsAutoViewMessageHandler: AutoMapViewApi {
     viewRegistry.getCarPlayView() != nil
   }
 
+  func isIndoorEnabled(viewId: Int64) throws -> Bool {
+    try getView().isIndoorEnabled()
+  }
+
+  func setIndoorEnabled(viewId: Int64, enabled: Bool) throws {
+    try getView().setIndoorEnabled(enabled)
+  }
+
+  func getFocusedIndoorBuilding(viewId: Int64) throws -> IndoorBuildingDto? {
+    try getView().getFocusedIndoorBuilding()
+  }
+
+  func activateIndoorLevel(viewId: Int64, levelIndex: Int64) throws {
+    try getView().activateIndoorLevel(Int(levelIndex))
+  }
+
   func setPadding(padding: MapPaddingDto) throws {
     try getView().setPadding(padding: padding)
   }

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsAutoViewMessageHandler.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsAutoViewMessageHandler.swift
@@ -544,19 +544,19 @@ class GoogleMapsAutoViewMessageHandler: AutoMapViewApi {
     viewRegistry.getCarPlayView() != nil
   }
 
-  func isIndoorEnabled(viewId: Int64) throws -> Bool {
+  func isIndoorEnabled() throws -> Bool {
     try getView().isIndoorEnabled()
   }
 
-  func setIndoorEnabled(viewId: Int64, enabled: Bool) throws {
+  func setIndoorEnabled(enabled: Bool) throws {
     try getView().setIndoorEnabled(enabled)
   }
 
-  func getFocusedIndoorBuilding(viewId: Int64) throws -> IndoorBuildingDto? {
+  func getFocusedIndoorBuilding() throws -> IndoorBuildingDto? {
     try getView().getFocusedIndoorBuilding()
   }
 
-  func activateIndoorLevel(viewId: Int64, levelIndex: Int64) throws {
+  func activateIndoorLevel(levelIndex: Int64) throws {
     try getView().activateIndoorLevel(Int(levelIndex))
   }
 

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationView.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationView.swift
@@ -62,6 +62,10 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
   // This allows BaseCarSceneDelegate to intercept and handle the event
   var promptVisibilityCallback: ((Bool) -> Void)?
 
+  // Callbacks for CarPlay views to handle indoor state changes.
+  var indoorFocusedBuildingChangedCallback: ((IndoorBuildingDto?) -> Void)?
+  var indoorActiveLevelChangedCallback: ((IndoorBuildingDto?) -> Void)?
+
   public func view() -> UIView {
     _mapView
   }
@@ -109,6 +113,7 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
 
     _mapView.delegate = self
     _mapView.viewSettledDelegate = self
+    _mapView.indoorDisplay.delegate = self
 
     _navigationUIEnabledPreference = navigationUIEnabledPreference
     applyNavigationUIEnabledPreference()
@@ -122,6 +127,7 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
   deinit {
     unregisterView()
     _mapView.delegate = nil
+    _mapView.indoorDisplay.delegate = nil
   }
 
   func registerView() {
@@ -395,6 +401,53 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
 
   func setBuildingsEnabled(_ enabled: Bool) {
     _mapView.isBuildingsEnabled = enabled
+  }
+
+  func isIndoorEnabled() -> Bool {
+    _mapView.isIndoorEnabled
+  }
+
+  func setIndoorEnabled(_ enabled: Bool) {
+    _mapView.isIndoorEnabled = enabled
+  }
+
+  func isIndoorLevelPickerEnabled() -> Bool {
+    _mapView.settings.indoorPicker
+  }
+
+  func setIndoorLevelPickerEnabled(_ enabled: Bool) {
+    _mapView.settings.indoorPicker = enabled
+  }
+
+  func getFocusedIndoorBuilding() -> IndoorBuildingDto? {
+    guard let building = _mapView.indoorDisplay.activeBuilding else {
+      return nil
+    }
+    return Convert.convertIndoorBuilding(
+      building: building,
+      activeLevel: _mapView.indoorDisplay.activeLevel
+    )
+  }
+
+  func activateIndoorLevel(_ levelIndex: Int) throws {
+    guard let building = _mapView.indoorDisplay.activeBuilding else {
+      throw PigeonError(
+        code: "indoorLevelActivationFailed",
+        message: "No indoor building is currently focused",
+        details: nil
+      )
+    }
+
+    if levelIndex < 0 || levelIndex >= building.levels.count {
+      throw PigeonError(
+        code: "indoorLevelActivationFailed",
+        message:
+          "Level index \(levelIndex) is out of range (building has \(building.levels.count) levels)",
+        details: nil
+      )
+    }
+
+    _mapView.indoorDisplay.activeLevel = building.levels[levelIndex]
   }
 
   func showRouteOverview() {
@@ -1131,6 +1184,48 @@ extension GoogleMapsNavigationView: GMSMapViewDelegate {
       getViewEventApi()?.onPromptVisibilityChanged(
         viewId: _viewId!,
         promptVisible: promptVisible,
+        completion: { _ in }
+      )
+    }
+  }
+}
+
+extension GoogleMapsNavigationView: GMSIndoorDisplayDelegate {
+  public func didChangeActiveBuilding(_ building: GMSIndoorBuilding?) {
+    let buildingDto: IndoorBuildingDto? = {
+      guard let building else { return nil }
+      return Convert.convertIndoorBuilding(
+        building: building,
+        activeLevel: _mapView.indoorDisplay.activeLevel
+      )
+    }()
+
+    if _isCarPlayView {
+      indoorFocusedBuildingChangedCallback?(buildingDto)
+    } else {
+      getViewEventApi()?.onIndoorFocusedBuildingChanged(
+        viewId: _viewId!,
+        building: buildingDto,
+        completion: { _ in }
+      )
+    }
+  }
+
+  public func didChangeActiveLevel(_ level: GMSIndoorLevel?) {
+    let buildingDto: IndoorBuildingDto? = {
+      guard let building = _mapView.indoorDisplay.activeBuilding else { return nil }
+      return Convert.convertIndoorBuilding(
+        building: building,
+        activeLevel: level
+      )
+    }()
+
+    if _isCarPlayView {
+      indoorActiveLevelChangedCallback?(buildingDto)
+    } else {
+      getViewEventApi()?.onIndoorActiveLevelChanged(
+        viewId: _viewId!,
+        building: buildingDto,
         completion: { _ in }
       )
     }

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewMessageHandler.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewMessageHandler.swift
@@ -438,6 +438,30 @@ class GoogleMapsNavigationViewMessageHandler: MapViewApi {
     try getView(viewId).setBuildingsEnabled(enabled)
   }
 
+  func isIndoorEnabled(viewId: Int64) throws -> Bool {
+    try getView(viewId).isIndoorEnabled()
+  }
+
+  func setIndoorEnabled(viewId: Int64, enabled: Bool) throws {
+    try getView(viewId).setIndoorEnabled(enabled)
+  }
+
+  func isIndoorLevelPickerEnabled(viewId: Int64) throws -> Bool {
+    try getView(viewId).isIndoorLevelPickerEnabled()
+  }
+
+  func setIndoorLevelPickerEnabled(viewId: Int64, enabled: Bool) throws {
+    try getView(viewId).setIndoorLevelPickerEnabled(enabled)
+  }
+
+  func getFocusedIndoorBuilding(viewId: Int64) throws -> IndoorBuildingDto? {
+    try getView(viewId).getFocusedIndoorBuilding()
+  }
+
+  func activateIndoorLevel(viewId: Int64, levelIndex: Int64) throws {
+    try getView(viewId).activateIndoorLevel(Int(levelIndex))
+  }
+
   func isTrafficPromptsEnabled(viewId: Int64) throws -> Bool {
     try getView(viewId).isTrafficPromptsEnabled()
   }

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/messages.g.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/messages.g.swift
@@ -6801,10 +6801,10 @@ protocol AutoMapViewApi {
   func isSpeedLimitIconEnabled() throws -> Bool
   func isSpeedometerEnabled() throws -> Bool
   func isNavigationUIEnabled() throws -> Bool
-  func isIndoorEnabled(viewId: Int64) throws -> Bool
-  func setIndoorEnabled(viewId: Int64, enabled: Bool) throws
-  func getFocusedIndoorBuilding(viewId: Int64) throws -> IndoorBuildingDto?
-  func activateIndoorLevel(viewId: Int64, levelIndex: Int64) throws
+  func isIndoorEnabled() throws -> Bool
+  func setIndoorEnabled(enabled: Bool) throws
+  func getFocusedIndoorBuilding() throws -> IndoorBuildingDto?
+  func activateIndoorLevel(levelIndex: Int64) throws
   func showRouteOverview() throws
   func getMarkers() throws -> [MarkerDto]
   func addMarkers(markers: [MarkerDto]) throws -> [MarkerDto]
@@ -7978,11 +7978,9 @@ class AutoMapViewApiSetup {
         "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isIndoorEnabled\(channelSuffix)",
       binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
-      isIndoorEnabledChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let viewIdArg = args[0] as! Int64
+      isIndoorEnabledChannel.setMessageHandler { _, reply in
         do {
-          let result = try api.isIndoorEnabled(viewId: viewIdArg)
+          let result = try api.isIndoorEnabled()
           reply(wrapResult(result))
         } catch {
           reply(wrapError(error))
@@ -7998,10 +7996,9 @@ class AutoMapViewApiSetup {
     if let api = api {
       setIndoorEnabledChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
-        let viewIdArg = args[0] as! Int64
-        let enabledArg = args[1] as! Bool
+        let enabledArg = args[0] as! Bool
         do {
-          try api.setIndoorEnabled(viewId: viewIdArg, enabled: enabledArg)
+          try api.setIndoorEnabled(enabled: enabledArg)
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))
@@ -8015,11 +8012,9 @@ class AutoMapViewApiSetup {
         "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.getFocusedIndoorBuilding\(channelSuffix)",
       binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
-      getFocusedIndoorBuildingChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let viewIdArg = args[0] as! Int64
+      getFocusedIndoorBuildingChannel.setMessageHandler { _, reply in
         do {
-          let result = try api.getFocusedIndoorBuilding(viewId: viewIdArg)
+          let result = try api.getFocusedIndoorBuilding()
           reply(wrapResult(result))
         } catch {
           reply(wrapError(error))
@@ -8035,10 +8030,9 @@ class AutoMapViewApiSetup {
     if let api = api {
       activateIndoorLevelChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
-        let viewIdArg = args[0] as! Int64
-        let levelIndexArg = args[1] as! Int64
+        let levelIndexArg = args[0] as! Int64
         do {
-          try api.activateIndoorLevel(viewId: viewIdArg, levelIndex: levelIndexArg)
+          try api.activateIndoorLevel(levelIndex: levelIndexArg)
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/messages.g.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/messages.g.swift
@@ -1006,6 +1006,82 @@ struct PointOfInterestDto: Hashable {
   }
 }
 
+/// Represents one indoor level of a focused indoor building.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct IndoorLevelDto: Hashable {
+  /// Full display name of the level.
+  var name: String? = nil
+  /// Short display name of the level.
+  var shortName: String? = nil
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> IndoorLevelDto? {
+    let name: String? = nilOrValue(pigeonVar_list[0])
+    let shortName: String? = nilOrValue(pigeonVar_list[1])
+
+    return IndoorLevelDto(
+      name: name,
+      shortName: shortName
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      name,
+      shortName,
+    ]
+  }
+  static func == (lhs: IndoorLevelDto, rhs: IndoorLevelDto) -> Bool {
+    return deepEqualsmessages(lhs.toList(), rhs.toList())
+  }
+  func hash(into hasher: inout Hasher) {
+    deepHashmessages(value: toList(), hasher: &hasher)
+  }
+}
+
+/// Represents focused indoor building metadata.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct IndoorBuildingDto: Hashable {
+  /// All levels available in the focused building.
+  var levels: [IndoorLevelDto?]
+  /// Currently active level index in [levels], if known.
+  var activeLevelIndex: Int64? = nil
+  /// Default level index in [levels], if known.
+  var defaultLevelIndex: Int64? = nil
+  /// Whether building is mostly underground, if known.
+  var isUnderground: Bool? = nil
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> IndoorBuildingDto? {
+    let levels = pigeonVar_list[0] as! [IndoorLevelDto?]
+    let activeLevelIndex: Int64? = nilOrValue(pigeonVar_list[1])
+    let defaultLevelIndex: Int64? = nilOrValue(pigeonVar_list[2])
+    let isUnderground: Bool? = nilOrValue(pigeonVar_list[3])
+
+    return IndoorBuildingDto(
+      levels: levels,
+      activeLevelIndex: activeLevelIndex,
+      defaultLevelIndex: defaultLevelIndex,
+      isUnderground: isUnderground
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      levels,
+      activeLevelIndex,
+      defaultLevelIndex,
+      isUnderground,
+    ]
+  }
+  static func == (lhs: IndoorBuildingDto, rhs: IndoorBuildingDto) -> Bool {
+    return deepEqualsmessages(lhs.toList(), rhs.toList())
+  }
+  func hash(into hasher: inout Hasher) {
+    deepHashmessages(value: toList(), hasher: &hasher)
+  }
+}
+
 /// Generated class from Pigeon that represents data sent in messages.
 struct PolygonDto: Hashable {
   var polygonId: String
@@ -2529,75 +2605,79 @@ private class MessagesPigeonCodecReader: FlutterStandardReader {
     case 165:
       return PointOfInterestDto.fromList(self.readValue() as! [Any?])
     case 166:
-      return PolygonDto.fromList(self.readValue() as! [Any?])
+      return IndoorLevelDto.fromList(self.readValue() as! [Any?])
     case 167:
-      return PolygonOptionsDto.fromList(self.readValue() as! [Any?])
+      return IndoorBuildingDto.fromList(self.readValue() as! [Any?])
     case 168:
-      return PolygonHoleDto.fromList(self.readValue() as! [Any?])
+      return PolygonDto.fromList(self.readValue() as! [Any?])
     case 169:
-      return StyleSpanStrokeStyleDto.fromList(self.readValue() as! [Any?])
+      return PolygonOptionsDto.fromList(self.readValue() as! [Any?])
     case 170:
-      return StyleSpanDto.fromList(self.readValue() as! [Any?])
+      return PolygonHoleDto.fromList(self.readValue() as! [Any?])
     case 171:
-      return PolylineDto.fromList(self.readValue() as! [Any?])
+      return StyleSpanStrokeStyleDto.fromList(self.readValue() as! [Any?])
     case 172:
-      return PatternItemDto.fromList(self.readValue() as! [Any?])
+      return StyleSpanDto.fromList(self.readValue() as! [Any?])
     case 173:
-      return PolylineOptionsDto.fromList(self.readValue() as! [Any?])
+      return PolylineDto.fromList(self.readValue() as! [Any?])
     case 174:
-      return CircleDto.fromList(self.readValue() as! [Any?])
+      return PatternItemDto.fromList(self.readValue() as! [Any?])
     case 175:
-      return CircleOptionsDto.fromList(self.readValue() as! [Any?])
+      return PolylineOptionsDto.fromList(self.readValue() as! [Any?])
     case 176:
-      return MapPaddingDto.fromList(self.readValue() as! [Any?])
+      return CircleDto.fromList(self.readValue() as! [Any?])
     case 177:
-      return RouteTokenOptionsDto.fromList(self.readValue() as! [Any?])
+      return CircleOptionsDto.fromList(self.readValue() as! [Any?])
     case 178:
-      return DestinationsDto.fromList(self.readValue() as! [Any?])
+      return MapPaddingDto.fromList(self.readValue() as! [Any?])
     case 179:
-      return RoutingOptionsDto.fromList(self.readValue() as! [Any?])
+      return RouteTokenOptionsDto.fromList(self.readValue() as! [Any?])
     case 180:
-      return NavigationDisplayOptionsDto.fromList(self.readValue() as! [Any?])
+      return DestinationsDto.fromList(self.readValue() as! [Any?])
     case 181:
-      return NavigationWaypointDto.fromList(self.readValue() as! [Any?])
+      return RoutingOptionsDto.fromList(self.readValue() as! [Any?])
     case 182:
-      return ContinueToNextDestinationResponseDto.fromList(self.readValue() as! [Any?])
+      return NavigationDisplayOptionsDto.fromList(self.readValue() as! [Any?])
     case 183:
-      return NavigationTimeAndDistanceDto.fromList(self.readValue() as! [Any?])
+      return NavigationWaypointDto.fromList(self.readValue() as! [Any?])
     case 184:
-      return NavigationAudioGuidanceSettingsDto.fromList(self.readValue() as! [Any?])
+      return ContinueToNextDestinationResponseDto.fromList(self.readValue() as! [Any?])
     case 185:
-      return SimulationOptionsDto.fromList(self.readValue() as! [Any?])
+      return NavigationTimeAndDistanceDto.fromList(self.readValue() as! [Any?])
     case 186:
-      return LatLngDto.fromList(self.readValue() as! [Any?])
+      return NavigationAudioGuidanceSettingsDto.fromList(self.readValue() as! [Any?])
     case 187:
-      return LatLngBoundsDto.fromList(self.readValue() as! [Any?])
+      return SimulationOptionsDto.fromList(self.readValue() as! [Any?])
     case 188:
-      return SpeedingUpdatedEventDto.fromList(self.readValue() as! [Any?])
+      return LatLngDto.fromList(self.readValue() as! [Any?])
     case 189:
-      return GpsAvailabilityChangeEventDto.fromList(self.readValue() as! [Any?])
+      return LatLngBoundsDto.fromList(self.readValue() as! [Any?])
     case 190:
-      return SpeedAlertOptionsThresholdPercentageDto.fromList(self.readValue() as! [Any?])
+      return SpeedingUpdatedEventDto.fromList(self.readValue() as! [Any?])
     case 191:
-      return SpeedAlertOptionsDto.fromList(self.readValue() as! [Any?])
+      return GpsAvailabilityChangeEventDto.fromList(self.readValue() as! [Any?])
     case 192:
+      return SpeedAlertOptionsThresholdPercentageDto.fromList(self.readValue() as! [Any?])
+    case 193:
+      return SpeedAlertOptionsDto.fromList(self.readValue() as! [Any?])
+    case 194:
       return RouteSegmentTrafficDataRoadStretchRenderingDataDto.fromList(
         self.readValue() as! [Any?])
-    case 193:
-      return RouteSegmentTrafficDataDto.fromList(self.readValue() as! [Any?])
-    case 194:
-      return RouteSegmentDto.fromList(self.readValue() as! [Any?])
     case 195:
-      return LaneDirectionDto.fromList(self.readValue() as! [Any?])
+      return RouteSegmentTrafficDataDto.fromList(self.readValue() as! [Any?])
     case 196:
-      return LaneDto.fromList(self.readValue() as! [Any?])
+      return RouteSegmentDto.fromList(self.readValue() as! [Any?])
     case 197:
-      return StepInfoDto.fromList(self.readValue() as! [Any?])
+      return LaneDirectionDto.fromList(self.readValue() as! [Any?])
     case 198:
-      return NavInfoDto.fromList(self.readValue() as! [Any?])
+      return LaneDto.fromList(self.readValue() as! [Any?])
     case 199:
-      return TermsAndConditionsUIParamsDto.fromList(self.readValue() as! [Any?])
+      return StepInfoDto.fromList(self.readValue() as! [Any?])
     case 200:
+      return NavInfoDto.fromList(self.readValue() as! [Any?])
+    case 201:
+      return TermsAndConditionsUIParamsDto.fromList(self.readValue() as! [Any?])
+    case 202:
       return StepImageGenerationOptionsDto.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -2718,110 +2798,116 @@ private class MessagesPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? PointOfInterestDto {
       super.writeByte(165)
       super.writeValue(value.toList())
-    } else if let value = value as? PolygonDto {
+    } else if let value = value as? IndoorLevelDto {
       super.writeByte(166)
       super.writeValue(value.toList())
-    } else if let value = value as? PolygonOptionsDto {
+    } else if let value = value as? IndoorBuildingDto {
       super.writeByte(167)
       super.writeValue(value.toList())
-    } else if let value = value as? PolygonHoleDto {
+    } else if let value = value as? PolygonDto {
       super.writeByte(168)
       super.writeValue(value.toList())
-    } else if let value = value as? StyleSpanStrokeStyleDto {
+    } else if let value = value as? PolygonOptionsDto {
       super.writeByte(169)
       super.writeValue(value.toList())
-    } else if let value = value as? StyleSpanDto {
+    } else if let value = value as? PolygonHoleDto {
       super.writeByte(170)
       super.writeValue(value.toList())
-    } else if let value = value as? PolylineDto {
+    } else if let value = value as? StyleSpanStrokeStyleDto {
       super.writeByte(171)
       super.writeValue(value.toList())
-    } else if let value = value as? PatternItemDto {
+    } else if let value = value as? StyleSpanDto {
       super.writeByte(172)
       super.writeValue(value.toList())
-    } else if let value = value as? PolylineOptionsDto {
+    } else if let value = value as? PolylineDto {
       super.writeByte(173)
       super.writeValue(value.toList())
-    } else if let value = value as? CircleDto {
+    } else if let value = value as? PatternItemDto {
       super.writeByte(174)
       super.writeValue(value.toList())
-    } else if let value = value as? CircleOptionsDto {
+    } else if let value = value as? PolylineOptionsDto {
       super.writeByte(175)
       super.writeValue(value.toList())
-    } else if let value = value as? MapPaddingDto {
+    } else if let value = value as? CircleDto {
       super.writeByte(176)
       super.writeValue(value.toList())
-    } else if let value = value as? RouteTokenOptionsDto {
+    } else if let value = value as? CircleOptionsDto {
       super.writeByte(177)
       super.writeValue(value.toList())
-    } else if let value = value as? DestinationsDto {
+    } else if let value = value as? MapPaddingDto {
       super.writeByte(178)
       super.writeValue(value.toList())
-    } else if let value = value as? RoutingOptionsDto {
+    } else if let value = value as? RouteTokenOptionsDto {
       super.writeByte(179)
       super.writeValue(value.toList())
-    } else if let value = value as? NavigationDisplayOptionsDto {
+    } else if let value = value as? DestinationsDto {
       super.writeByte(180)
       super.writeValue(value.toList())
-    } else if let value = value as? NavigationWaypointDto {
+    } else if let value = value as? RoutingOptionsDto {
       super.writeByte(181)
       super.writeValue(value.toList())
-    } else if let value = value as? ContinueToNextDestinationResponseDto {
+    } else if let value = value as? NavigationDisplayOptionsDto {
       super.writeByte(182)
       super.writeValue(value.toList())
-    } else if let value = value as? NavigationTimeAndDistanceDto {
+    } else if let value = value as? NavigationWaypointDto {
       super.writeByte(183)
       super.writeValue(value.toList())
-    } else if let value = value as? NavigationAudioGuidanceSettingsDto {
+    } else if let value = value as? ContinueToNextDestinationResponseDto {
       super.writeByte(184)
       super.writeValue(value.toList())
-    } else if let value = value as? SimulationOptionsDto {
+    } else if let value = value as? NavigationTimeAndDistanceDto {
       super.writeByte(185)
       super.writeValue(value.toList())
-    } else if let value = value as? LatLngDto {
+    } else if let value = value as? NavigationAudioGuidanceSettingsDto {
       super.writeByte(186)
       super.writeValue(value.toList())
-    } else if let value = value as? LatLngBoundsDto {
+    } else if let value = value as? SimulationOptionsDto {
       super.writeByte(187)
       super.writeValue(value.toList())
-    } else if let value = value as? SpeedingUpdatedEventDto {
+    } else if let value = value as? LatLngDto {
       super.writeByte(188)
       super.writeValue(value.toList())
-    } else if let value = value as? GpsAvailabilityChangeEventDto {
+    } else if let value = value as? LatLngBoundsDto {
       super.writeByte(189)
       super.writeValue(value.toList())
-    } else if let value = value as? SpeedAlertOptionsThresholdPercentageDto {
+    } else if let value = value as? SpeedingUpdatedEventDto {
       super.writeByte(190)
       super.writeValue(value.toList())
-    } else if let value = value as? SpeedAlertOptionsDto {
+    } else if let value = value as? GpsAvailabilityChangeEventDto {
       super.writeByte(191)
       super.writeValue(value.toList())
-    } else if let value = value as? RouteSegmentTrafficDataRoadStretchRenderingDataDto {
+    } else if let value = value as? SpeedAlertOptionsThresholdPercentageDto {
       super.writeByte(192)
       super.writeValue(value.toList())
-    } else if let value = value as? RouteSegmentTrafficDataDto {
+    } else if let value = value as? SpeedAlertOptionsDto {
       super.writeByte(193)
       super.writeValue(value.toList())
-    } else if let value = value as? RouteSegmentDto {
+    } else if let value = value as? RouteSegmentTrafficDataRoadStretchRenderingDataDto {
       super.writeByte(194)
       super.writeValue(value.toList())
-    } else if let value = value as? LaneDirectionDto {
+    } else if let value = value as? RouteSegmentTrafficDataDto {
       super.writeByte(195)
       super.writeValue(value.toList())
-    } else if let value = value as? LaneDto {
+    } else if let value = value as? RouteSegmentDto {
       super.writeByte(196)
       super.writeValue(value.toList())
-    } else if let value = value as? StepInfoDto {
+    } else if let value = value as? LaneDirectionDto {
       super.writeByte(197)
       super.writeValue(value.toList())
-    } else if let value = value as? NavInfoDto {
+    } else if let value = value as? LaneDto {
       super.writeByte(198)
       super.writeValue(value.toList())
-    } else if let value = value as? TermsAndConditionsUIParamsDto {
+    } else if let value = value as? StepInfoDto {
       super.writeByte(199)
       super.writeValue(value.toList())
-    } else if let value = value as? StepImageGenerationOptionsDto {
+    } else if let value = value as? NavInfoDto {
       super.writeByte(200)
+      super.writeValue(value.toList())
+    } else if let value = value as? TermsAndConditionsUIParamsDto {
+      super.writeByte(201)
+      super.writeValue(value.toList())
+    } else if let value = value as? StepImageGenerationOptionsDto {
+      super.writeByte(202)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -2938,6 +3024,15 @@ protocol MapViewApi {
   func showReportIncidentsPanel(viewId: Int64) throws
   func isBuildingsEnabled(viewId: Int64) throws -> Bool
   func setBuildingsEnabled(viewId: Int64, enabled: Bool) throws
+  func isIndoorEnabled(viewId: Int64) throws -> Bool
+  func setIndoorEnabled(viewId: Int64, enabled: Bool) throws
+  func isIndoorLevelPickerEnabled(viewId: Int64) throws -> Bool
+  func setIndoorLevelPickerEnabled(viewId: Int64, enabled: Bool) throws
+  func getFocusedIndoorBuilding(viewId: Int64) throws -> IndoorBuildingDto?
+  /// Activates the indoor level at [levelIndex] within the currently focused
+  /// indoor building. Throws if no building is focused or the index is out of
+  /// range.
+  func activateIndoorLevel(viewId: Int64, levelIndex: Int64) throws
   func getCameraPosition(viewId: Int64) throws -> CameraPositionDto
   func getVisibleRegion(viewId: Int64) throws -> LatLngBoundsDto
   func followMyLocation(viewId: Int64, perspective: CameraPerspectiveDto, zoomLevel: Double?) throws
@@ -3989,6 +4084,120 @@ class MapViewApiSetup {
       }
     } else {
       setBuildingsEnabledChannel.setMessageHandler(nil)
+    }
+    let isIndoorEnabledChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorEnabled\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      isIndoorEnabledChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] as! Int64
+        do {
+          let result = try api.isIndoorEnabled(viewId: viewIdArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      isIndoorEnabledChannel.setMessageHandler(nil)
+    }
+    let setIndoorEnabledChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorEnabled\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      setIndoorEnabledChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] as! Int64
+        let enabledArg = args[1] as! Bool
+        do {
+          try api.setIndoorEnabled(viewId: viewIdArg, enabled: enabledArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      setIndoorEnabledChannel.setMessageHandler(nil)
+    }
+    let isIndoorLevelPickerEnabledChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorLevelPickerEnabled\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      isIndoorLevelPickerEnabledChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] as! Int64
+        do {
+          let result = try api.isIndoorLevelPickerEnabled(viewId: viewIdArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      isIndoorLevelPickerEnabledChannel.setMessageHandler(nil)
+    }
+    let setIndoorLevelPickerEnabledChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorLevelPickerEnabled\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      setIndoorLevelPickerEnabledChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] as! Int64
+        let enabledArg = args[1] as! Bool
+        do {
+          try api.setIndoorLevelPickerEnabled(viewId: viewIdArg, enabled: enabledArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      setIndoorLevelPickerEnabledChannel.setMessageHandler(nil)
+    }
+    let getFocusedIndoorBuildingChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.getFocusedIndoorBuilding\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      getFocusedIndoorBuildingChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] as! Int64
+        do {
+          let result = try api.getFocusedIndoorBuilding(viewId: viewIdArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      getFocusedIndoorBuildingChannel.setMessageHandler(nil)
+    }
+    /// Activates the indoor level at [levelIndex] within the currently focused
+    /// indoor building. Throws if no building is focused or the index is out of
+    /// range.
+    let activateIndoorLevelChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.google_navigation_flutter.MapViewApi.activateIndoorLevel\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      activateIndoorLevelChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] as! Int64
+        let levelIndexArg = args[1] as! Int64
+        do {
+          try api.activateIndoorLevel(viewId: viewIdArg, levelIndex: levelIndexArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      activateIndoorLevelChannel.setMessageHandler(nil)
     }
     let getCameraPositionChannel = FlutterBasicMessageChannel(
       name:
@@ -5131,6 +5340,12 @@ protocol ViewEventApiProtocol {
     viewId viewIdArg: Int64, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onMyLocationButtonClicked(
     viewId viewIdArg: Int64, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onIndoorFocusedBuildingChanged(
+    viewId viewIdArg: Int64, building buildingArg: IndoorBuildingDto?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onIndoorActiveLevelChanged(
+    viewId viewIdArg: Int64, building buildingArg: IndoorBuildingDto?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onCameraChanged(
     viewId viewIdArg: Int64, eventType eventTypeArg: CameraEventTypeDto,
     position positionArg: CameraPositionDto,
@@ -5430,6 +5645,52 @@ class ViewEventApi: ViewEventApiProtocol {
     let channel = FlutterBasicMessageChannel(
       name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([viewIdArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  func onIndoorFocusedBuildingChanged(
+    viewId viewIdArg: Int64, building buildingArg: IndoorBuildingDto?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void
+  ) {
+    let channelName: String =
+      "dev.flutter.pigeon.google_navigation_flutter.ViewEventApi.onIndoorFocusedBuildingChanged\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([viewIdArg, buildingArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  func onIndoorActiveLevelChanged(
+    viewId viewIdArg: Int64, building buildingArg: IndoorBuildingDto?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void
+  ) {
+    let channelName: String =
+      "dev.flutter.pigeon.google_navigation_flutter.ViewEventApi.onIndoorActiveLevelChanged\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([viewIdArg, buildingArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
         return
@@ -6540,6 +6801,10 @@ protocol AutoMapViewApi {
   func isSpeedLimitIconEnabled() throws -> Bool
   func isSpeedometerEnabled() throws -> Bool
   func isNavigationUIEnabled() throws -> Bool
+  func isIndoorEnabled(viewId: Int64) throws -> Bool
+  func setIndoorEnabled(viewId: Int64, enabled: Bool) throws
+  func getFocusedIndoorBuilding(viewId: Int64) throws -> IndoorBuildingDto?
+  func activateIndoorLevel(viewId: Int64, levelIndex: Int64) throws
   func showRouteOverview() throws
   func getMarkers() throws -> [MarkerDto]
   func addMarkers(markers: [MarkerDto]) throws -> [MarkerDto]
@@ -7708,6 +7973,80 @@ class AutoMapViewApiSetup {
     } else {
       isNavigationUIEnabledChannel.setMessageHandler(nil)
     }
+    let isIndoorEnabledChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isIndoorEnabled\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      isIndoorEnabledChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] as! Int64
+        do {
+          let result = try api.isIndoorEnabled(viewId: viewIdArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      isIndoorEnabledChannel.setMessageHandler(nil)
+    }
+    let setIndoorEnabledChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      setIndoorEnabledChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] as! Int64
+        let enabledArg = args[1] as! Bool
+        do {
+          try api.setIndoorEnabled(viewId: viewIdArg, enabled: enabledArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      setIndoorEnabledChannel.setMessageHandler(nil)
+    }
+    let getFocusedIndoorBuildingChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.getFocusedIndoorBuilding\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      getFocusedIndoorBuildingChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] as! Int64
+        do {
+          let result = try api.getFocusedIndoorBuilding(viewId: viewIdArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      getFocusedIndoorBuildingChannel.setMessageHandler(nil)
+    }
+    let activateIndoorLevelChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      activateIndoorLevelChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] as! Int64
+        let levelIndexArg = args[1] as! Int64
+        do {
+          try api.activateIndoorLevel(viewId: viewIdArg, levelIndex: levelIndexArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      activateIndoorLevelChannel.setMessageHandler(nil)
+    }
     let showRouteOverviewChannel = FlutterBasicMessageChannel(
       name:
         "dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.showRouteOverview\(channelSuffix)",
@@ -8247,6 +8586,12 @@ protocol AutoViewEventApiProtocol {
     isAvailable isAvailableArg: Bool, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onPromptVisibilityChanged(
     promptVisible promptVisibleArg: Bool, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onIndoorFocusedBuildingChanged(
+    building buildingArg: IndoorBuildingDto?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onIndoorActiveLevelChanged(
+    building buildingArg: IndoorBuildingDto?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void)
 }
 class AutoViewEventApi: AutoViewEventApiProtocol {
   private let binaryMessenger: FlutterBinaryMessenger
@@ -8311,6 +8656,52 @@ class AutoViewEventApi: AutoViewEventApiProtocol {
     let channel = FlutterBasicMessageChannel(
       name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([promptVisibleArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  func onIndoorFocusedBuildingChanged(
+    building buildingArg: IndoorBuildingDto?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void
+  ) {
+    let channelName: String =
+      "dev.flutter.pigeon.google_navigation_flutter.AutoViewEventApi.onIndoorFocusedBuildingChanged\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([buildingArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  func onIndoorActiveLevelChanged(
+    building buildingArg: IndoorBuildingDto?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void
+  ) {
+    let channelName: String =
+      "dev.flutter.pigeon.google_navigation_flutter.AutoViewEventApi.onIndoorActiveLevelChanged\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([buildingArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
         return

--- a/lib/src/google_maps_auto_view_controller.dart
+++ b/lib/src/google_maps_auto_view_controller.dart
@@ -412,6 +412,31 @@ class GoogleMapsAutoViewController {
         .isAutoScreenAvailable();
   }
 
+  /// Returns whether indoor maps are enabled on the Android Auto or CarPlay map view.
+  Future<bool> isIndoorEnabled() {
+    return GoogleMapsNavigationPlatform.instance.autoAPI.isIndoorEnabled();
+  }
+
+  /// Enables or disables indoor maps on the Android Auto or CarPlay map view.
+  Future<void> setIndoorEnabled(bool enabled) {
+    return GoogleMapsNavigationPlatform.instance.autoAPI.setIndoorEnabled(
+      enabled: enabled,
+    );
+  }
+
+  /// Gets metadata for the currently focused indoor building, if available.
+  Future<IndoorBuilding?> getFocusedIndoorBuilding() {
+    return GoogleMapsNavigationPlatform.instance.autoAPI
+        .getFocusedIndoorBuilding();
+  }
+
+  /// Activates an indoor level on the currently focused indoor building.
+  Future<void> activateIndoorLevel(IndoorLevel indoorLevel) {
+    return GoogleMapsNavigationPlatform.instance.autoAPI.activateIndoorLevel(
+      levelIndex: indoorLevel.levelIndex,
+    );
+  }
+
   /// Enable or disable traffic prompts on the Android Auto or CarPlay map view.
   ///
   /// When enabled, traffic prompts are displayed on the map during navigation
@@ -707,6 +732,28 @@ class GoogleMapsAutoViewController {
     GoogleMapsNavigationPlatform.instance.autoAPI
         .getPromptVisibilityChangedEventStream()
         .listen((PromptVisibilityChangedEvent event) {
+          func(event);
+        });
+  }
+
+  /// Listens for focused indoor building changes on Android Auto or CarPlay.
+  void listenForIndoorFocusedBuildingChangedEvent(
+    void Function(IndoorFocusedBuildingChangedEvent event) func,
+  ) {
+    GoogleMapsNavigationPlatform.instance.autoAPI
+        .getIndoorFocusedBuildingChangedEventStream()
+        .listen((IndoorFocusedBuildingChangedEvent event) {
+          func(event);
+        });
+  }
+
+  /// Listens for active indoor level changes on Android Auto or CarPlay.
+  void listenForIndoorActiveLevelChangedEvent(
+    void Function(IndoorActiveLevelChangedEvent event) func,
+  ) {
+    GoogleMapsNavigationPlatform.instance.autoAPI
+        .getIndoorActiveLevelChangedEventStream()
+        .listen((IndoorActiveLevelChangedEvent event) {
           func(event);
         });
   }

--- a/lib/src/google_maps_exceptions.dart
+++ b/lib/src/google_maps_exceptions.dart
@@ -217,6 +217,28 @@ class ImageDecodingFailedException
   static const platformCode = 'imageDecodingFailed';
 }
 
+/// [GoogleNavigationViewController.activateIndoorLevel] failed.
+///
+/// The failure reason is described by the exception message (for example,
+/// no focused indoor building or level index out of range).
+/// {@category Navigation View}
+/// {@category Map View}
+class IndoorLevelActivationException
+    extends GoogleMapsNavigationPlatformException {
+  /// Creates an [IndoorLevelActivationException] from an original
+  /// [PlatformException].
+  IndoorLevelActivationException({required PlatformException exception})
+    : assert(exception.code == platformCode),
+      super(
+        code: exception.code,
+        message: exception.message ?? 'Indoor level activation failed.',
+        details: exception.details,
+        stacktrace: exception.stacktrace,
+      );
+
+  static const platformCode = 'indoorLevelActivationFailed';
+}
+
 /// Platform code for unsupported features.
 ///
 /// Used internally by [convertPlatformException] to convert
@@ -247,6 +269,8 @@ Object convertPlatformException(Object exception, StackTrace stacktrace) {
         return MinZoomRangeException(exception: exception);
       case ImageDecodingFailedException.platformCode:
         return ImageDecodingFailedException(exception: exception);
+      case IndoorLevelActivationException.platformCode:
+        return IndoorLevelActivationException(exception: exception);
       case ViewNotFoundException.platformCode:
         return ViewNotFoundException(
           exception: exception,

--- a/lib/src/google_maps_map_view.dart
+++ b/lib/src/google_maps_map_view.dart
@@ -62,6 +62,8 @@ abstract class GoogleMapsBaseMapView extends StatefulWidget {
     this.onPolylineClicked,
     this.onCircleClicked,
     this.onPoiClicked,
+    this.onIndoorFocusedBuildingChanged,
+    this.onIndoorActiveLevelChanged,
     this.onMyLocationClicked,
     this.onMyLocationButtonClicked,
     this.onCameraMoveStarted,
@@ -227,6 +229,12 @@ abstract class GoogleMapsBaseMapView extends StatefulWidget {
   /// On POI (Point of Interest) clicked callback.
   final OnPoiClicked? onPoiClicked;
 
+  /// On focused indoor building changed callback.
+  final OnIndoorFocusedBuildingChanged? onIndoorFocusedBuildingChanged;
+
+  /// On active indoor level changed callback.
+  final OnIndoorActiveLevelChanged? onIndoorActiveLevelChanged;
+
   /// On my location clicked callback.
   final OnMyLocationClicked? onMyLocationClicked;
 
@@ -304,6 +312,8 @@ class GoogleMapsMapView extends GoogleMapsBaseMapView {
     super.onPolylineClicked,
     super.onCircleClicked,
     super.onPoiClicked,
+    super.onIndoorFocusedBuildingChanged,
+    super.onIndoorActiveLevelChanged,
     super.onMyLocationClicked,
     super.onMyLocationButtonClicked,
     super.onCameraMoveStarted,
@@ -431,6 +441,22 @@ abstract class MapViewState<T extends GoogleMapsBaseMapView> extends State<T> {
           .getPoiClickedEventStream(viewId: viewId)
           .listen((PoiClickedEvent event) {
             widget.onPoiClicked?.call(event.pointOfInterest);
+          });
+    }
+
+    if (widget.onIndoorFocusedBuildingChanged != null) {
+      GoogleMapsNavigationPlatform.instance.viewAPI
+          .getIndoorFocusedBuildingChangedEventStream(viewId: viewId)
+          .listen((IndoorFocusedBuildingChangedEvent event) {
+            widget.onIndoorFocusedBuildingChanged?.call(event.building);
+          });
+    }
+
+    if (widget.onIndoorActiveLevelChanged != null) {
+      GoogleMapsNavigationPlatform.instance.viewAPI
+          .getIndoorActiveLevelChangedEventStream(viewId: viewId)
+          .listen((IndoorActiveLevelChangedEvent event) {
+            widget.onIndoorActiveLevelChanged?.call(event.building);
           });
     }
 

--- a/lib/src/google_maps_map_view_controller.dart
+++ b/lib/src/google_maps_map_view_controller.dart
@@ -203,6 +203,37 @@ class GoogleMapViewController {
     );
   }
 
+  /// Checks if the indoor maps layer is enabled.
+  Future<bool> isIndoorEnabled() {
+    return GoogleMapsNavigationPlatform.instance.viewAPI.isIndoorEnabled(
+      viewId: _viewId,
+    );
+  }
+
+  /// Enable or disable the indoor maps layer.
+  Future<void> setIndoorEnabled(bool enabled) {
+    return GoogleMapsNavigationPlatform.instance.viewAPI.setIndoorEnabled(
+      viewId: _viewId,
+      enabled: enabled,
+    );
+  }
+
+  /// Gets the currently focused indoor building, if available.
+  Future<IndoorBuilding?> getFocusedIndoorBuilding() {
+    return GoogleMapsNavigationPlatform.instance.viewAPI
+        .getFocusedIndoorBuilding(viewId: _viewId);
+  }
+
+  /// Activates an indoor level within the currently focused indoor building.
+  ///
+  /// Throws if no building is currently focused or the index is out of range.
+  Future<void> activateIndoorLevel(IndoorLevel indoorLevel) {
+    return GoogleMapsNavigationPlatform.instance.viewAPI.activateIndoorLevel(
+      viewId: _viewId,
+      levelIndex: indoorLevel.levelIndex,
+    );
+  }
+
   /// Returns the minimum zoom level preference from the map view.
   /// If minimum zoom preference is not set previously, returns minimum possible
   /// zoom level for the current map type.

--- a/lib/src/google_maps_navigation_view.dart
+++ b/lib/src/google_maps_navigation_view.dart
@@ -81,6 +81,8 @@ class GoogleMapsNavigationView extends GoogleMapsBaseMapView {
     super.onPolylineClicked,
     super.onCircleClicked,
     super.onPoiClicked,
+    super.onIndoorFocusedBuildingChanged,
+    super.onIndoorActiveLevelChanged,
     this.onNavigationUIEnabledChanged,
     this.onPromptVisibilityChanged,
     super.onMyLocationClicked,

--- a/lib/src/google_navigation_flutter.dart
+++ b/lib/src/google_navigation_flutter.dart
@@ -116,6 +116,13 @@ typedef OnCircleClicked = void Function(String circleId);
 /// POIs include parks, schools, government buildings, and businesses.
 typedef OnPoiClicked = void Function(PointOfInterest pointOfInterest);
 
+/// Called when the focused indoor building changes.
+typedef OnIndoorFocusedBuildingChanged =
+    void Function(IndoorBuilding? building);
+
+/// Called when the active indoor level changes.
+typedef OnIndoorActiveLevelChanged = void Function(IndoorBuilding? building);
+
 /// Called when the [GoogleNavigationViewController.isNavigationUIEnabled] status changes.
 typedef OnNavigationUIEnabledChanged = void Function(bool navigationUIEnabled);
 
@@ -301,6 +308,12 @@ class NavigationViewUISettings {
     );
   }
 
+  /// Enables or disables the indoor level picker.
+  Future<void> setIndoorLevelPickerEnabled(bool enabled) {
+    return GoogleMapsNavigationPlatform.instance.viewAPI
+        .setIndoorLevelPickerEnabled(viewId: _viewId, enabled: enabled);
+  }
+
   /// Checks if the my location button is enabled.
   Future<bool> isMyLocationButtonEnabled() async {
     return GoogleMapsNavigationPlatform.instance.viewAPI
@@ -369,6 +382,12 @@ class NavigationViewUISettings {
     return GoogleMapsNavigationPlatform.instance.viewAPI.isMapToolbarEnabled(
       viewId: _viewId,
     );
+  }
+
+  /// Checks if the indoor level picker is enabled.
+  Future<bool> isIndoorLevelPickerEnabled() async {
+    return GoogleMapsNavigationPlatform.instance.viewAPI
+        .isIndoorLevelPickerEnabled(viewId: _viewId);
   }
 
   /// Checks if the map is displaying traffic data.

--- a/lib/src/method_channel/auto_view_api.dart
+++ b/lib/src/method_channel/auto_view_api.dart
@@ -739,23 +739,27 @@ class AutoMapViewAPIImpl {
 
   /// Gets whether indoor maps are enabled for the auto view.
   Future<bool> isIndoorEnabled() =>
-      _viewApi.isIndoorEnabled(0).wrapPlatformException();
+      _viewApi.isIndoorEnabled().wrapPlatformException();
 
   /// Enables or disables indoor maps for the auto view.
   Future<void> setIndoorEnabled({required bool enabled}) =>
-      _viewApi.setIndoorEnabled(0, enabled).wrapPlatformException();
+      _viewApi.setIndoorEnabled(enabled).wrapPlatformException();
 
   /// Returns the currently focused indoor building, if available.
   Future<IndoorBuilding?> getFocusedIndoorBuilding() async {
     final IndoorBuildingDto? building = await _viewApi
-        .getFocusedIndoorBuilding(0)
+        .getFocusedIndoorBuilding()
         .wrapPlatformException();
     return building?.toIndoorBuilding();
   }
 
   /// Activates an indoor level in the currently focused indoor building.
-  Future<void> activateIndoorLevel({required int levelIndex}) =>
-      _viewApi.activateIndoorLevel(0, levelIndex).wrapPlatformException();
+  ///
+  /// Asserts that [levelIndex] is greater than or equal to 0.
+  Future<void> activateIndoorLevel({required int levelIndex}) {
+    assert(levelIndex >= 0, 'levelIndex must be greater than or equal to 0');
+    return _viewApi.activateIndoorLevel(levelIndex).wrapPlatformException();
+  }
 
   /// Get custom navigation auto event stream from the auto view.
   Stream<CustomNavigationAutoEvent> getCustomNavigationAutoEventStream() {

--- a/lib/src/method_channel/auto_view_api.dart
+++ b/lib/src/method_channel/auto_view_api.dart
@@ -67,9 +67,8 @@ class AutoMapViewAPIImpl {
   }
 
   Stream<T> _unwrapEventStream<T>() {
-    // If event that does not
     return _autoEventStreamController.stream
-        .where((_AutoEventWrapper wrapper) => (wrapper.event is T))
+        .where((_AutoEventWrapper wrapper) => wrapper.event is T)
         .map<T>((_AutoEventWrapper wrapper) => wrapper.event as T);
   }
 
@@ -738,6 +737,26 @@ class AutoMapViewAPIImpl {
   Future<bool> isAutoScreenAvailable() =>
       _viewApi.isAutoScreenAvailable().wrapPlatformException();
 
+  /// Gets whether indoor maps are enabled for the auto view.
+  Future<bool> isIndoorEnabled() =>
+      _viewApi.isIndoorEnabled(0).wrapPlatformException();
+
+  /// Enables or disables indoor maps for the auto view.
+  Future<void> setIndoorEnabled({required bool enabled}) =>
+      _viewApi.setIndoorEnabled(0, enabled).wrapPlatformException();
+
+  /// Returns the currently focused indoor building, if available.
+  Future<IndoorBuilding?> getFocusedIndoorBuilding() async {
+    final IndoorBuildingDto? building = await _viewApi
+        .getFocusedIndoorBuilding(0)
+        .wrapPlatformException();
+    return building?.toIndoorBuilding();
+  }
+
+  /// Activates an indoor level in the currently focused indoor building.
+  Future<void> activateIndoorLevel({required int levelIndex}) =>
+      _viewApi.activateIndoorLevel(0, levelIndex).wrapPlatformException();
+
   /// Get custom navigation auto event stream from the auto view.
   Stream<CustomNavigationAutoEvent> getCustomNavigationAutoEventStream() {
     return _unwrapEventStream<CustomNavigationAutoEvent>();
@@ -752,6 +771,18 @@ class AutoMapViewAPIImpl {
   /// Get prompt visibility changed event stream from the auto view.
   Stream<PromptVisibilityChangedEvent> getPromptVisibilityChangedEventStream() {
     return _unwrapEventStream<PromptVisibilityChangedEvent>();
+  }
+
+  /// Get focused indoor building changed event stream from the auto view.
+  Stream<IndoorFocusedBuildingChangedEvent>
+  getIndoorFocusedBuildingChangedEventStream() {
+    return _unwrapEventStream<IndoorFocusedBuildingChangedEvent>();
+  }
+
+  /// Get active indoor level changed event stream from the auto view.
+  Stream<IndoorActiveLevelChangedEvent>
+  getIndoorActiveLevelChangedEventStream() {
+    return _unwrapEventStream<IndoorActiveLevelChangedEvent>();
   }
 
   Future<void> setTrafficPromptsEnabled({required bool enabled}) {
@@ -863,6 +894,24 @@ class AutoViewEventApiImpl implements AutoViewEventApi {
   void onPromptVisibilityChanged(bool promptVisible) {
     _viewEventStreamController.add(
       _AutoEventWrapper(PromptVisibilityChangedEvent(promptVisible)),
+    );
+  }
+
+  @override
+  void onIndoorFocusedBuildingChanged(IndoorBuildingDto? building) {
+    _viewEventStreamController.add(
+      _AutoEventWrapper(
+        IndoorFocusedBuildingChangedEvent(building?.toIndoorBuilding()),
+      ),
+    );
+  }
+
+  @override
+  void onIndoorActiveLevelChanged(IndoorBuildingDto? building) {
+    _viewEventStreamController.add(
+      _AutoEventWrapper(
+        IndoorActiveLevelChangedEvent(building?.toIndoorBuilding()),
+      ),
     );
   }
 }

--- a/lib/src/method_channel/convert/convert.dart
+++ b/lib/src/method_channel/convert/convert.dart
@@ -15,6 +15,7 @@
 export 'camera.dart';
 export 'circle.dart';
 export 'destinations.dart';
+export 'indoor.dart';
 export 'latlng.dart';
 export 'latlng_bounds.dart';
 export 'map_color_scheme.dart';

--- a/lib/src/method_channel/convert/indoor.dart
+++ b/lib/src/method_channel/convert/indoor.dart
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '../../types/types.dart';
+import '../method_channel.dart';
+
+/// [IndoorLevelDto] convert extension.
+/// @nodoc
+extension ConvertIndoorLevelDto on IndoorLevelDto {
+  /// Converts [IndoorLevelDto] to [IndoorLevel].
+  IndoorLevel toIndoorLevel({required int levelIndex}) {
+    return IndoorLevel(
+      levelIndex: levelIndex,
+      name: name,
+      shortName: shortName,
+    );
+  }
+}
+
+/// [IndoorBuildingDto] convert extension.
+/// @nodoc
+extension ConvertIndoorBuildingDto on IndoorBuildingDto {
+  /// Converts [IndoorBuildingDto] to [IndoorBuilding].
+  IndoorBuilding toIndoorBuilding() {
+    return IndoorBuilding(
+      levels: levels
+          .asMap()
+          .entries
+          .where((e) => e.value != null)
+          .map((e) => e.value!.toIndoorLevel(levelIndex: e.key))
+          .toList(),
+      activeLevelIndex: activeLevelIndex,
+      defaultLevelIndex: defaultLevelIndex,
+      isUnderground: isUnderground,
+    );
+  }
+}

--- a/lib/src/method_channel/map_view_api.dart
+++ b/lib/src/method_channel/map_view_api.dart
@@ -623,6 +623,45 @@ class MapViewAPIImpl {
     required bool enabled,
   }) => _viewApi.setBuildingsEnabled(viewId, enabled).wrapPlatformException();
 
+  /// Checks if indoor maps layer is enabled.
+  Future<bool> isIndoorEnabled({required int viewId}) =>
+      _viewApi.isIndoorEnabled(viewId).wrapPlatformException();
+
+  /// Turns indoor maps layer on or off.
+  Future<void> setIndoorEnabled({required int viewId, required bool enabled}) =>
+      _viewApi.setIndoorEnabled(viewId, enabled).wrapPlatformException();
+
+  /// Checks if indoor level picker is enabled.
+  Future<bool> isIndoorLevelPickerEnabled({required int viewId}) =>
+      _viewApi.isIndoorLevelPickerEnabled(viewId).wrapPlatformException();
+
+  /// Turns indoor level picker on or off.
+  Future<void> setIndoorLevelPickerEnabled({
+    required int viewId,
+    required bool enabled,
+  }) => _viewApi
+      .setIndoorLevelPickerEnabled(viewId, enabled)
+      .wrapPlatformException();
+
+  /// Gets currently focused indoor building, if any.
+  Future<IndoorBuilding?> getFocusedIndoorBuilding({
+    required int viewId,
+  }) async {
+    final IndoorBuildingDto? building = await _viewApi
+        .getFocusedIndoorBuilding(viewId)
+        .wrapPlatformException();
+    return building?.toIndoorBuilding();
+  }
+
+  /// Activates the indoor level at [levelIndex] in the currently focused building.
+  ///
+  /// Throws if no building is currently focused or the index is out of range.
+  Future<void> activateIndoorLevel({
+    required int viewId,
+    required int levelIndex,
+  }) =>
+      _viewApi.activateIndoorLevel(viewId, levelIndex).wrapPlatformException();
+
   /// Are the traffic prompts displayed.
   Future<bool> isTrafficPromptsEnabled({required int viewId}) =>
       _viewApi.isTrafficPromptsEnabled(viewId).wrapPlatformException();
@@ -1143,6 +1182,21 @@ class MapViewAPIImpl {
   }) {
     return _unwrapEventStream<CameraChangedEvent>(viewId: viewId);
   }
+
+  /// Get focused indoor building changed event stream from the map view.
+  Stream<IndoorFocusedBuildingChangedEvent>
+  getIndoorFocusedBuildingChangedEventStream({required int viewId}) {
+    return _unwrapEventStream<IndoorFocusedBuildingChangedEvent>(
+      viewId: viewId,
+    );
+  }
+
+  /// Get indoor active level changed event stream from the map view.
+  Stream<IndoorActiveLevelChangedEvent> getIndoorActiveLevelChangedEventStream({
+    required int viewId,
+  }) {
+    return _unwrapEventStream<IndoorActiveLevelChangedEvent>(viewId: viewId);
+  }
 }
 
 /// Implementation for navigation view event API event handling.
@@ -1267,6 +1321,26 @@ class ViewEventApiImpl implements ViewEventApi {
   void onMyLocationButtonClicked(int viewId) {
     _viewEventStreamController.add(
       _ViewIdEventWrapper(viewId, MyLocationButtonClickedEvent()),
+    );
+  }
+
+  @override
+  void onIndoorFocusedBuildingChanged(int viewId, IndoorBuildingDto? building) {
+    _viewEventStreamController.add(
+      _ViewIdEventWrapper(
+        viewId,
+        IndoorFocusedBuildingChangedEvent(building?.toIndoorBuilding()),
+      ),
+    );
+  }
+
+  @override
+  void onIndoorActiveLevelChanged(int viewId, IndoorBuildingDto? building) {
+    _viewEventStreamController.add(
+      _ViewIdEventWrapper(
+        viewId,
+        IndoorActiveLevelChangedEvent(building?.toIndoorBuilding()),
+      ),
     );
   }
 

--- a/lib/src/method_channel/map_view_api.dart
+++ b/lib/src/method_channel/map_view_api.dart
@@ -655,12 +655,17 @@ class MapViewAPIImpl {
 
   /// Activates the indoor level at [levelIndex] in the currently focused building.
   ///
-  /// Throws if no building is currently focused or the index is out of range.
+  /// Asserts that [levelIndex] is greater than or equal to 0.
+  /// Native code throws if no building is currently focused or the index is out of range.
   Future<void> activateIndoorLevel({
     required int viewId,
     required int levelIndex,
-  }) =>
-      _viewApi.activateIndoorLevel(viewId, levelIndex).wrapPlatformException();
+  }) {
+    assert(levelIndex >= 0, 'levelIndex must be greater than or equal to 0');
+    return _viewApi
+        .activateIndoorLevel(viewId, levelIndex)
+        .wrapPlatformException();
+  }
 
   /// Are the traffic prompts displayed.
   Future<bool> isTrafficPromptsEnabled({required int viewId}) =>

--- a/lib/src/method_channel/messages.g.dart
+++ b/lib/src/method_channel/messages.g.dart
@@ -11100,7 +11100,7 @@ class AutoMapViewApi {
     }
   }
 
-  Future<bool> isIndoorEnabled(int viewId) async {
+  Future<bool> isIndoorEnabled() async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isIndoorEnabled$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
@@ -11109,9 +11109,7 @@ class AutoMapViewApi {
           pigeonChannelCodec,
           binaryMessenger: pigeonVar_binaryMessenger,
         );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[viewId],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -11132,7 +11130,7 @@ class AutoMapViewApi {
     }
   }
 
-  Future<void> setIndoorEnabled(int viewId, bool enabled) async {
+  Future<void> setIndoorEnabled(bool enabled) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
@@ -11142,7 +11140,7 @@ class AutoMapViewApi {
           binaryMessenger: pigeonVar_binaryMessenger,
         );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[viewId, enabled],
+      <Object?>[enabled],
     );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
@@ -11159,7 +11157,7 @@ class AutoMapViewApi {
     }
   }
 
-  Future<IndoorBuildingDto?> getFocusedIndoorBuilding(int viewId) async {
+  Future<IndoorBuildingDto?> getFocusedIndoorBuilding() async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.getFocusedIndoorBuilding$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
@@ -11168,9 +11166,7 @@ class AutoMapViewApi {
           pigeonChannelCodec,
           binaryMessenger: pigeonVar_binaryMessenger,
         );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[viewId],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -11186,7 +11182,7 @@ class AutoMapViewApi {
     }
   }
 
-  Future<void> activateIndoorLevel(int viewId, int levelIndex) async {
+  Future<void> activateIndoorLevel(int levelIndex) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
@@ -11196,7 +11192,7 @@ class AutoMapViewApi {
           binaryMessenger: pigeonVar_binaryMessenger,
         );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[viewId, levelIndex],
+      <Object?>[levelIndex],
     );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;

--- a/lib/src/method_channel/messages.g.dart
+++ b/lib/src/method_channel/messages.g.dart
@@ -1130,6 +1130,110 @@ class PointOfInterestDto {
   int get hashCode => Object.hashAll(_toList());
 }
 
+/// Represents one indoor level of a focused indoor building.
+class IndoorLevelDto {
+  IndoorLevelDto({this.name, this.shortName});
+
+  /// Full display name of the level.
+  String? name;
+
+  /// Short display name of the level.
+  String? shortName;
+
+  List<Object?> _toList() {
+    return <Object?>[name, shortName];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static IndoorLevelDto decode(Object result) {
+    result as List<Object?>;
+    return IndoorLevelDto(
+      name: result[0] as String?,
+      shortName: result[1] as String?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! IndoorLevelDto || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
+/// Represents focused indoor building metadata.
+class IndoorBuildingDto {
+  IndoorBuildingDto({
+    required this.levels,
+    this.activeLevelIndex,
+    this.defaultLevelIndex,
+    this.isUnderground,
+  });
+
+  /// All levels available in the focused building.
+  List<IndoorLevelDto?> levels;
+
+  /// Currently active level index in [levels], if known.
+  int? activeLevelIndex;
+
+  /// Default level index in [levels], if known.
+  int? defaultLevelIndex;
+
+  /// Whether building is mostly underground, if known.
+  bool? isUnderground;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      levels,
+      activeLevelIndex,
+      defaultLevelIndex,
+      isUnderground,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static IndoorBuildingDto decode(Object result) {
+    result as List<Object?>;
+    return IndoorBuildingDto(
+      levels: (result[0] as List<Object?>?)!.cast<IndoorLevelDto?>(),
+      activeLevelIndex: result[1] as int?,
+      defaultLevelIndex: result[2] as int?,
+      isUnderground: result[3] as bool?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! IndoorBuildingDto || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
 class PolygonDto {
   PolygonDto({required this.polygonId, required this.options});
 
@@ -3126,110 +3230,116 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PointOfInterestDto) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is PolygonDto) {
+    } else if (value is IndoorLevelDto) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is PolygonOptionsDto) {
+    } else if (value is IndoorBuildingDto) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is PolygonHoleDto) {
+    } else if (value is PolygonDto) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is StyleSpanStrokeStyleDto) {
+    } else if (value is PolygonOptionsDto) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is StyleSpanDto) {
+    } else if (value is PolygonHoleDto) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is PolylineDto) {
+    } else if (value is StyleSpanStrokeStyleDto) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is PatternItemDto) {
+    } else if (value is StyleSpanDto) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is PolylineOptionsDto) {
+    } else if (value is PolylineDto) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is CircleDto) {
+    } else if (value is PatternItemDto) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is CircleOptionsDto) {
+    } else if (value is PolylineOptionsDto) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is MapPaddingDto) {
+    } else if (value is CircleDto) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is RouteTokenOptionsDto) {
+    } else if (value is CircleOptionsDto) {
       buffer.putUint8(177);
       writeValue(buffer, value.encode());
-    } else if (value is DestinationsDto) {
+    } else if (value is MapPaddingDto) {
       buffer.putUint8(178);
       writeValue(buffer, value.encode());
-    } else if (value is RoutingOptionsDto) {
+    } else if (value is RouteTokenOptionsDto) {
       buffer.putUint8(179);
       writeValue(buffer, value.encode());
-    } else if (value is NavigationDisplayOptionsDto) {
+    } else if (value is DestinationsDto) {
       buffer.putUint8(180);
       writeValue(buffer, value.encode());
-    } else if (value is NavigationWaypointDto) {
+    } else if (value is RoutingOptionsDto) {
       buffer.putUint8(181);
       writeValue(buffer, value.encode());
-    } else if (value is ContinueToNextDestinationResponseDto) {
+    } else if (value is NavigationDisplayOptionsDto) {
       buffer.putUint8(182);
       writeValue(buffer, value.encode());
-    } else if (value is NavigationTimeAndDistanceDto) {
+    } else if (value is NavigationWaypointDto) {
       buffer.putUint8(183);
       writeValue(buffer, value.encode());
-    } else if (value is NavigationAudioGuidanceSettingsDto) {
+    } else if (value is ContinueToNextDestinationResponseDto) {
       buffer.putUint8(184);
       writeValue(buffer, value.encode());
-    } else if (value is SimulationOptionsDto) {
+    } else if (value is NavigationTimeAndDistanceDto) {
       buffer.putUint8(185);
       writeValue(buffer, value.encode());
-    } else if (value is LatLngDto) {
+    } else if (value is NavigationAudioGuidanceSettingsDto) {
       buffer.putUint8(186);
       writeValue(buffer, value.encode());
-    } else if (value is LatLngBoundsDto) {
+    } else if (value is SimulationOptionsDto) {
       buffer.putUint8(187);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedingUpdatedEventDto) {
+    } else if (value is LatLngDto) {
       buffer.putUint8(188);
       writeValue(buffer, value.encode());
-    } else if (value is GpsAvailabilityChangeEventDto) {
+    } else if (value is LatLngBoundsDto) {
       buffer.putUint8(189);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedAlertOptionsThresholdPercentageDto) {
+    } else if (value is SpeedingUpdatedEventDto) {
       buffer.putUint8(190);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedAlertOptionsDto) {
+    } else if (value is GpsAvailabilityChangeEventDto) {
       buffer.putUint8(191);
       writeValue(buffer, value.encode());
-    } else if (value is RouteSegmentTrafficDataRoadStretchRenderingDataDto) {
+    } else if (value is SpeedAlertOptionsThresholdPercentageDto) {
       buffer.putUint8(192);
       writeValue(buffer, value.encode());
-    } else if (value is RouteSegmentTrafficDataDto) {
+    } else if (value is SpeedAlertOptionsDto) {
       buffer.putUint8(193);
       writeValue(buffer, value.encode());
-    } else if (value is RouteSegmentDto) {
+    } else if (value is RouteSegmentTrafficDataRoadStretchRenderingDataDto) {
       buffer.putUint8(194);
       writeValue(buffer, value.encode());
-    } else if (value is LaneDirectionDto) {
+    } else if (value is RouteSegmentTrafficDataDto) {
       buffer.putUint8(195);
       writeValue(buffer, value.encode());
-    } else if (value is LaneDto) {
+    } else if (value is RouteSegmentDto) {
       buffer.putUint8(196);
       writeValue(buffer, value.encode());
-    } else if (value is StepInfoDto) {
+    } else if (value is LaneDirectionDto) {
       buffer.putUint8(197);
       writeValue(buffer, value.encode());
-    } else if (value is NavInfoDto) {
+    } else if (value is LaneDto) {
       buffer.putUint8(198);
       writeValue(buffer, value.encode());
-    } else if (value is TermsAndConditionsUIParamsDto) {
+    } else if (value is StepInfoDto) {
       buffer.putUint8(199);
       writeValue(buffer, value.encode());
-    } else if (value is StepImageGenerationOptionsDto) {
+    } else if (value is NavInfoDto) {
       buffer.putUint8(200);
+      writeValue(buffer, value.encode());
+    } else if (value is TermsAndConditionsUIParamsDto) {
+      buffer.putUint8(201);
+      writeValue(buffer, value.encode());
+    } else if (value is StepImageGenerationOptionsDto) {
+      buffer.putUint8(202);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -3347,78 +3457,82 @@ class _PigeonCodec extends StandardMessageCodec {
       case 165:
         return PointOfInterestDto.decode(readValue(buffer)!);
       case 166:
-        return PolygonDto.decode(readValue(buffer)!);
+        return IndoorLevelDto.decode(readValue(buffer)!);
       case 167:
-        return PolygonOptionsDto.decode(readValue(buffer)!);
+        return IndoorBuildingDto.decode(readValue(buffer)!);
       case 168:
-        return PolygonHoleDto.decode(readValue(buffer)!);
+        return PolygonDto.decode(readValue(buffer)!);
       case 169:
-        return StyleSpanStrokeStyleDto.decode(readValue(buffer)!);
+        return PolygonOptionsDto.decode(readValue(buffer)!);
       case 170:
-        return StyleSpanDto.decode(readValue(buffer)!);
+        return PolygonHoleDto.decode(readValue(buffer)!);
       case 171:
-        return PolylineDto.decode(readValue(buffer)!);
+        return StyleSpanStrokeStyleDto.decode(readValue(buffer)!);
       case 172:
-        return PatternItemDto.decode(readValue(buffer)!);
+        return StyleSpanDto.decode(readValue(buffer)!);
       case 173:
-        return PolylineOptionsDto.decode(readValue(buffer)!);
+        return PolylineDto.decode(readValue(buffer)!);
       case 174:
-        return CircleDto.decode(readValue(buffer)!);
+        return PatternItemDto.decode(readValue(buffer)!);
       case 175:
-        return CircleOptionsDto.decode(readValue(buffer)!);
+        return PolylineOptionsDto.decode(readValue(buffer)!);
       case 176:
-        return MapPaddingDto.decode(readValue(buffer)!);
+        return CircleDto.decode(readValue(buffer)!);
       case 177:
-        return RouteTokenOptionsDto.decode(readValue(buffer)!);
+        return CircleOptionsDto.decode(readValue(buffer)!);
       case 178:
-        return DestinationsDto.decode(readValue(buffer)!);
+        return MapPaddingDto.decode(readValue(buffer)!);
       case 179:
-        return RoutingOptionsDto.decode(readValue(buffer)!);
+        return RouteTokenOptionsDto.decode(readValue(buffer)!);
       case 180:
-        return NavigationDisplayOptionsDto.decode(readValue(buffer)!);
+        return DestinationsDto.decode(readValue(buffer)!);
       case 181:
-        return NavigationWaypointDto.decode(readValue(buffer)!);
+        return RoutingOptionsDto.decode(readValue(buffer)!);
       case 182:
-        return ContinueToNextDestinationResponseDto.decode(readValue(buffer)!);
+        return NavigationDisplayOptionsDto.decode(readValue(buffer)!);
       case 183:
-        return NavigationTimeAndDistanceDto.decode(readValue(buffer)!);
+        return NavigationWaypointDto.decode(readValue(buffer)!);
       case 184:
-        return NavigationAudioGuidanceSettingsDto.decode(readValue(buffer)!);
+        return ContinueToNextDestinationResponseDto.decode(readValue(buffer)!);
       case 185:
-        return SimulationOptionsDto.decode(readValue(buffer)!);
+        return NavigationTimeAndDistanceDto.decode(readValue(buffer)!);
       case 186:
-        return LatLngDto.decode(readValue(buffer)!);
+        return NavigationAudioGuidanceSettingsDto.decode(readValue(buffer)!);
       case 187:
-        return LatLngBoundsDto.decode(readValue(buffer)!);
+        return SimulationOptionsDto.decode(readValue(buffer)!);
       case 188:
-        return SpeedingUpdatedEventDto.decode(readValue(buffer)!);
+        return LatLngDto.decode(readValue(buffer)!);
       case 189:
-        return GpsAvailabilityChangeEventDto.decode(readValue(buffer)!);
+        return LatLngBoundsDto.decode(readValue(buffer)!);
       case 190:
+        return SpeedingUpdatedEventDto.decode(readValue(buffer)!);
+      case 191:
+        return GpsAvailabilityChangeEventDto.decode(readValue(buffer)!);
+      case 192:
         return SpeedAlertOptionsThresholdPercentageDto.decode(
           readValue(buffer)!,
         );
-      case 191:
+      case 193:
         return SpeedAlertOptionsDto.decode(readValue(buffer)!);
-      case 192:
+      case 194:
         return RouteSegmentTrafficDataRoadStretchRenderingDataDto.decode(
           readValue(buffer)!,
         );
-      case 193:
-        return RouteSegmentTrafficDataDto.decode(readValue(buffer)!);
-      case 194:
-        return RouteSegmentDto.decode(readValue(buffer)!);
       case 195:
-        return LaneDirectionDto.decode(readValue(buffer)!);
+        return RouteSegmentTrafficDataDto.decode(readValue(buffer)!);
       case 196:
-        return LaneDto.decode(readValue(buffer)!);
+        return RouteSegmentDto.decode(readValue(buffer)!);
       case 197:
-        return StepInfoDto.decode(readValue(buffer)!);
+        return LaneDirectionDto.decode(readValue(buffer)!);
       case 198:
-        return NavInfoDto.decode(readValue(buffer)!);
+        return LaneDto.decode(readValue(buffer)!);
       case 199:
-        return TermsAndConditionsUIParamsDto.decode(readValue(buffer)!);
+        return StepInfoDto.decode(readValue(buffer)!);
       case 200:
+        return NavInfoDto.decode(readValue(buffer)!);
+      case 201:
+        return TermsAndConditionsUIParamsDto.decode(readValue(buffer)!);
+      case 202:
         return StepImageGenerationOptionsDto.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -5043,6 +5157,181 @@ class MapViewApi {
         );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[viewId, enabled],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<bool> isIndoorEnabled(int viewId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorEnabled$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[viewId],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as bool?)!;
+    }
+  }
+
+  Future<void> setIndoorEnabled(int viewId, bool enabled) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorEnabled$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[viewId, enabled],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<bool> isIndoorLevelPickerEnabled(int viewId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorLevelPickerEnabled$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[viewId],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as bool?)!;
+    }
+  }
+
+  Future<void> setIndoorLevelPickerEnabled(int viewId, bool enabled) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorLevelPickerEnabled$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[viewId, enabled],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<IndoorBuildingDto?> getFocusedIndoorBuilding(int viewId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.getFocusedIndoorBuilding$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[viewId],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return (pigeonVar_replyList[0] as IndoorBuildingDto?);
+    }
+  }
+
+  /// Activates the indoor level at [levelIndex] within the currently focused
+  /// indoor building. Throws if no building is focused or the index is out of
+  /// range.
+  Future<void> activateIndoorLevel(int viewId, int levelIndex) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.activateIndoorLevel$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[viewId, levelIndex],
     );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
@@ -6864,6 +7153,10 @@ abstract class ViewEventApi {
 
   void onMyLocationButtonClicked(int viewId);
 
+  void onIndoorFocusedBuildingChanged(int viewId, IndoorBuildingDto? building);
+
+  void onIndoorActiveLevelChanged(int viewId, IndoorBuildingDto? building);
+
   void onCameraChanged(
     int viewId,
     CameraEventTypeDto eventType,
@@ -7385,6 +7678,78 @@ abstract class ViewEventApi {
           );
           try {
             api.onMyLocationButtonClicked(arg_viewId!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.ViewEventApi.onIndoorFocusedBuildingChanged$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.ViewEventApi.onIndoorFocusedBuildingChanged was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_viewId = (args[0] as int?);
+          assert(
+            arg_viewId != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.ViewEventApi.onIndoorFocusedBuildingChanged was null, expected non-null int.',
+          );
+          final IndoorBuildingDto? arg_building =
+              (args[1] as IndoorBuildingDto?);
+          try {
+            api.onIndoorFocusedBuildingChanged(arg_viewId!, arg_building);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.ViewEventApi.onIndoorActiveLevelChanged$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.ViewEventApi.onIndoorActiveLevelChanged was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_viewId = (args[0] as int?);
+          assert(
+            arg_viewId != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.ViewEventApi.onIndoorActiveLevelChanged was null, expected non-null int.',
+          );
+          final IndoorBuildingDto? arg_building =
+              (args[1] as IndoorBuildingDto?);
+          try {
+            api.onIndoorActiveLevelChanged(arg_viewId!, arg_building);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
@@ -10735,6 +11100,119 @@ class AutoMapViewApi {
     }
   }
 
+  Future<bool> isIndoorEnabled(int viewId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isIndoorEnabled$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[viewId],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as bool?)!;
+    }
+  }
+
+  Future<void> setIndoorEnabled(int viewId, bool enabled) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[viewId, enabled],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<IndoorBuildingDto?> getFocusedIndoorBuilding(int viewId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.getFocusedIndoorBuilding$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[viewId],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return (pigeonVar_replyList[0] as IndoorBuildingDto?);
+    }
+  }
+
+  Future<void> activateIndoorLevel(int viewId, int levelIndex) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[viewId, levelIndex],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
   Future<void> showRouteOverview() async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.showRouteOverview$pigeonVar_messageChannelSuffix';
@@ -11634,6 +12112,10 @@ abstract class AutoViewEventApi {
 
   void onPromptVisibilityChanged(bool promptVisible);
 
+  void onIndoorFocusedBuildingChanged(IndoorBuildingDto? building);
+
+  void onIndoorActiveLevelChanged(IndoorBuildingDto? building);
+
   static void setUp(
     AutoViewEventApi? api, {
     BinaryMessenger? binaryMessenger,
@@ -11738,6 +12220,68 @@ abstract class AutoViewEventApi {
           );
           try {
             api.onPromptVisibilityChanged(arg_promptVisible!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.AutoViewEventApi.onIndoorFocusedBuildingChanged$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoViewEventApi.onIndoorFocusedBuildingChanged was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final IndoorBuildingDto? arg_building =
+              (args[0] as IndoorBuildingDto?);
+          try {
+            api.onIndoorFocusedBuildingChanged(arg_building);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.AutoViewEventApi.onIndoorActiveLevelChanged$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoViewEventApi.onIndoorActiveLevelChanged was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final IndoorBuildingDto? arg_building =
+              (args[0] as IndoorBuildingDto?);
+          try {
+            api.onIndoorActiveLevelChanged(arg_building);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/lib/src/types/navigation_view_types.dart
+++ b/lib/src/types/navigation_view_types.dart
@@ -289,6 +289,123 @@ class PoiClickedEvent {
   String toString() => 'PoiClickedEvent(pointOfInterest: $pointOfInterest)';
 }
 
+/// Represents one indoor level in a focused indoor building.
+/// {@category Navigation View}
+/// {@category Map View}
+@immutable
+class IndoorLevel {
+  /// Creates an [IndoorLevel] object.
+  const IndoorLevel({
+    required this.levelIndex,
+    required this.name,
+    required this.shortName,
+  });
+
+  /// Stable index of this level within the containing focused building levels list.
+  final int levelIndex;
+
+  /// Full display name of the level.
+  final String? name;
+
+  /// Short display name of the level.
+  final String? shortName;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is IndoorLevel &&
+        levelIndex == other.levelIndex &&
+        name == other.name &&
+        shortName == other.shortName;
+  }
+
+  @override
+  int get hashCode => Object.hash(levelIndex, name, shortName);
+
+  @override
+  String toString() =>
+      'IndoorLevel(levelIndex: $levelIndex, name: $name, shortName: $shortName)';
+}
+
+/// Represents focused indoor building metadata.
+/// {@category Navigation View}
+/// {@category Map View}
+@immutable
+class IndoorBuilding {
+  /// Creates an [IndoorBuilding] object.
+  const IndoorBuilding({
+    required this.levels,
+    this.activeLevelIndex,
+    this.defaultLevelIndex,
+    this.isUnderground,
+  });
+
+  /// All levels available in the focused building.
+  final List<IndoorLevel> levels;
+
+  /// Currently active level index in [levels], if known.
+  final int? activeLevelIndex;
+
+  /// Default level index in [levels], if known.
+  final int? defaultLevelIndex;
+
+  /// Whether the building is underground, if known.
+  final bool? isUnderground;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is IndoorBuilding &&
+        listEquals(levels, other.levels) &&
+        activeLevelIndex == other.activeLevelIndex &&
+        defaultLevelIndex == other.defaultLevelIndex &&
+        isUnderground == other.isUnderground;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    Object.hashAll(levels),
+    activeLevelIndex,
+    defaultLevelIndex,
+    isUnderground,
+  );
+
+  @override
+  String toString() =>
+      'IndoorBuilding(levels: $levels, activeLevelIndex: $activeLevelIndex, '
+      'defaultLevelIndex: $defaultLevelIndex, isUnderground: $isUnderground)';
+}
+
+/// Event emitted when focused indoor building changes.
+/// {@category Navigation View}
+/// {@category Map View}
+@immutable
+class IndoorFocusedBuildingChangedEvent {
+  const IndoorFocusedBuildingChangedEvent(this.building);
+
+  final IndoorBuilding? building;
+}
+
+/// Event emitted when active indoor level changes.
+/// {@category Navigation View}
+/// {@category Map View}
+@immutable
+class IndoorActiveLevelChangedEvent {
+  const IndoorActiveLevelChangedEvent(this.building);
+
+  final IndoorBuilding? building;
+}
+
 /// Traffic data statuses
 /// {@category Navigation View}
 enum RouteSegmentTrafficDataStatus {

--- a/pigeons/messages.dart
+++ b/pigeons/messages.dart
@@ -1673,10 +1673,10 @@ abstract class AutoMapViewApi {
   bool isSpeedometerEnabled();
   bool isNavigationUIEnabled();
 
-  bool isIndoorEnabled(int viewId);
-  void setIndoorEnabled(int viewId, bool enabled);
-  IndoorBuildingDto? getFocusedIndoorBuilding(int viewId);
-  void activateIndoorLevel(int viewId, int levelIndex);
+  bool isIndoorEnabled();
+  void setIndoorEnabled(bool enabled);
+  IndoorBuildingDto? getFocusedIndoorBuilding();
+  void activateIndoorLevel(int levelIndex);
 
   void showRouteOverview();
 

--- a/pigeons/messages.dart
+++ b/pigeons/messages.dart
@@ -337,6 +337,39 @@ class PointOfInterestDto {
   final LatLngDto latLng;
 }
 
+/// Represents one indoor level of a focused indoor building.
+class IndoorLevelDto {
+  const IndoorLevelDto({required this.name, required this.shortName});
+
+  /// Full display name of the level.
+  final String? name;
+
+  /// Short display name of the level.
+  final String? shortName;
+}
+
+/// Represents focused indoor building metadata.
+class IndoorBuildingDto {
+  const IndoorBuildingDto({
+    required this.levels,
+    this.activeLevelIndex,
+    this.defaultLevelIndex,
+    this.isUnderground,
+  });
+
+  /// All levels available in the focused building.
+  final List<IndoorLevelDto?> levels;
+
+  /// Currently active level index in [levels], if known.
+  final int? activeLevelIndex;
+
+  /// Default level index in [levels], if known.
+  final int? defaultLevelIndex;
+
+  /// Whether building is mostly underground, if known.
+  final bool? isUnderground;
+}
+
 class PolygonDto {
   const PolygonDto({required this.polygonId, required this.options});
 
@@ -574,6 +607,19 @@ abstract class MapViewApi {
   bool isBuildingsEnabled(int viewId);
   void setBuildingsEnabled(int viewId, bool enabled);
 
+  bool isIndoorEnabled(int viewId);
+  void setIndoorEnabled(int viewId, bool enabled);
+
+  bool isIndoorLevelPickerEnabled(int viewId);
+  void setIndoorLevelPickerEnabled(int viewId, bool enabled);
+
+  IndoorBuildingDto? getFocusedIndoorBuilding(int viewId);
+
+  /// Activates the indoor level at [levelIndex] within the currently focused
+  /// indoor building. Throws if no building is focused or the index is out of
+  /// range.
+  void activateIndoorLevel(int viewId, int levelIndex);
+
   CameraPositionDto getCameraPosition(int viewId);
   LatLngBoundsDto getVisibleRegion(int viewId);
 
@@ -719,6 +765,8 @@ abstract class ViewEventApi {
   void onPromptVisibilityChanged(int viewId, bool promptVisible);
   void onMyLocationClicked(int viewId);
   void onMyLocationButtonClicked(int viewId);
+  void onIndoorFocusedBuildingChanged(int viewId, IndoorBuildingDto? building);
+  void onIndoorActiveLevelChanged(int viewId, IndoorBuildingDto? building);
   void onCameraChanged(
     int viewId,
     CameraEventTypeDto eventType,
@@ -1625,6 +1673,11 @@ abstract class AutoMapViewApi {
   bool isSpeedometerEnabled();
   bool isNavigationUIEnabled();
 
+  bool isIndoorEnabled(int viewId);
+  void setIndoorEnabled(int viewId, bool enabled);
+  IndoorBuildingDto? getFocusedIndoorBuilding(int viewId);
+  void activateIndoorLevel(int viewId, int levelIndex);
+
   void showRouteOverview();
 
   List<MarkerDto> getMarkers();
@@ -1670,6 +1723,8 @@ abstract class AutoViewEventApi {
   void onCustomNavigationAutoEvent(String event, Object data);
   void onAutoScreenAvailabilityChanged(bool isAvailable);
   void onPromptVisibilityChanged(bool promptVisible);
+  void onIndoorFocusedBuildingChanged(IndoorBuildingDto? building);
+  void onIndoorActiveLevelChanged(IndoorBuildingDto? building);
 }
 
 @HostApi()

--- a/test/auto/auto_event_api_test.dart
+++ b/test/auto/auto_event_api_test.dart
@@ -242,5 +242,60 @@ void main() {
         expect(promptEvents[1].promptVisible, false);
       },
     );
+
+    test('IndoorFocusedBuildingChangedEvent stream receives events', () async {
+      IndoorFocusedBuildingChangedEvent? receivedEvent;
+      final IndoorBuildingDto buildingDto = IndoorBuildingDto(
+        levels: <IndoorLevelDto>[
+          IndoorLevelDto(name: 'Level 1', shortName: 'L1'),
+          IndoorLevelDto(name: 'Level 2', shortName: 'L2'),
+        ],
+        activeLevelIndex: 1,
+        defaultLevelIndex: 0,
+        isUnderground: false,
+      );
+
+      testAutoApi.getIndoorFocusedBuildingChangedEventStream().listen((
+        IndoorFocusedBuildingChangedEvent event,
+      ) {
+        receivedEvent = event;
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      testAutoApi.testEventApi.onIndoorFocusedBuildingChanged(buildingDto);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(receivedEvent, isNotNull);
+      expect(receivedEvent!.building, isNotNull);
+      expect(receivedEvent!.building!.levels.length, 2);
+      expect(receivedEvent!.building!.activeLevelIndex, 1);
+    });
+
+    test('IndoorActiveLevelChangedEvent stream receives events', () async {
+      IndoorActiveLevelChangedEvent? receivedEvent;
+      final IndoorBuildingDto buildingDto = IndoorBuildingDto(
+        levels: <IndoorLevelDto>[
+          IndoorLevelDto(name: 'Level 1', shortName: 'L1'),
+          IndoorLevelDto(name: 'Level 2', shortName: 'L2'),
+        ],
+        activeLevelIndex: 0,
+        defaultLevelIndex: 0,
+        isUnderground: false,
+      );
+
+      testAutoApi.getIndoorActiveLevelChangedEventStream().listen((
+        IndoorActiveLevelChangedEvent event,
+      ) {
+        receivedEvent = event;
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      testAutoApi.testEventApi.onIndoorActiveLevelChanged(buildingDto);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(receivedEvent, isNotNull);
+      expect(receivedEvent!.building, isNotNull);
+      expect(receivedEvent!.building!.activeLevelIndex, 0);
+    });
   });
 }

--- a/test/auto/auto_view_api_test.dart
+++ b/test/auto/auto_view_api_test.dart
@@ -259,7 +259,7 @@ void main() {
 
         group('Indoor controls', () {
           test('isIndoorEnabled returns value', () async {
-            when(autoViewMockApi.isIndoorEnabled(any)).thenReturn(true);
+            when(autoViewMockApi.isIndoorEnabled(0)).thenReturn(true);
 
             final bool result = await GoogleMapsNavigationPlatform
                 .instance
@@ -291,7 +291,7 @@ void main() {
               isUnderground: false,
             );
             when(
-              autoViewMockApi.getFocusedIndoorBuilding(any),
+              autoViewMockApi.getFocusedIndoorBuilding(0),
             ).thenReturn(buildingDto);
 
             final IndoorBuilding? building = await GoogleMapsNavigationPlatform

--- a/test/auto/auto_view_api_test.dart
+++ b/test/auto/auto_view_api_test.dart
@@ -259,7 +259,7 @@ void main() {
 
         group('Indoor controls', () {
           test('isIndoorEnabled returns value', () async {
-            when(autoViewMockApi.isIndoorEnabled(0)).thenReturn(true);
+            when(autoViewMockApi.isIndoorEnabled()).thenReturn(true);
 
             final bool result = await GoogleMapsNavigationPlatform
                 .instance
@@ -267,7 +267,7 @@ void main() {
                 .isIndoorEnabled();
 
             expect(result, true);
-            verify(autoViewMockApi.isIndoorEnabled(0)).called(1);
+            verify(autoViewMockApi.isIndoorEnabled()).called(1);
           });
 
           test(
@@ -276,7 +276,7 @@ void main() {
               await GoogleMapsNavigationPlatform.instance.autoAPI
                   .setIndoorEnabled(enabled: true);
 
-              verify(autoViewMockApi.setIndoorEnabled(0, true)).called(1);
+              verify(autoViewMockApi.setIndoorEnabled(true)).called(1);
             },
           );
 
@@ -291,7 +291,7 @@ void main() {
               isUnderground: false,
             );
             when(
-              autoViewMockApi.getFocusedIndoorBuilding(0),
+              autoViewMockApi.getFocusedIndoorBuilding(),
             ).thenReturn(buildingDto);
 
             final IndoorBuilding? building = await GoogleMapsNavigationPlatform
@@ -302,7 +302,7 @@ void main() {
             expect(building, isNotNull);
             expect(building!.levels.length, 2);
             expect(building.activeLevelIndex, 1);
-            verify(autoViewMockApi.getFocusedIndoorBuilding(0)).called(1);
+            verify(autoViewMockApi.getFocusedIndoorBuilding()).called(1);
           });
 
           test(
@@ -311,7 +311,38 @@ void main() {
               await GoogleMapsNavigationPlatform.instance.autoAPI
                   .activateIndoorLevel(levelIndex: 2);
 
-              verify(autoViewMockApi.activateIndoorLevel(0, 2)).called(1);
+              verify(autoViewMockApi.activateIndoorLevel(2)).called(1);
+            },
+          );
+
+          test('activateIndoorLevel rejects negative level index', () async {
+            expect(
+              () => GoogleMapsNavigationPlatform.instance.autoAPI
+                  .activateIndoorLevel(levelIndex: -1),
+              throwsA(isA<AssertionError>()),
+            );
+
+            verifyNever(autoViewMockApi.activateIndoorLevel(any));
+          });
+
+          test(
+            'GoogleMapsAutoViewController.activateIndoorLevel rejects negative IndoorLevel index',
+            () async {
+              final GoogleMapsAutoViewController controller =
+                  GoogleMapsAutoViewController();
+
+              expect(
+                () => controller.activateIndoorLevel(
+                  const IndoorLevel(
+                    levelIndex: -1,
+                    name: 'Basement',
+                    shortName: 'B1',
+                  ),
+                ),
+                throwsA(isA<AssertionError>()),
+              );
+
+              verifyNever(autoViewMockApi.activateIndoorLevel(any));
             },
           );
         });

--- a/test/auto/auto_view_api_test.dart
+++ b/test/auto/auto_view_api_test.dart
@@ -257,6 +257,65 @@ void main() {
           });
         });
 
+        group('Indoor controls', () {
+          test('isIndoorEnabled returns value', () async {
+            when(autoViewMockApi.isIndoorEnabled(any)).thenReturn(true);
+
+            final bool result = await GoogleMapsNavigationPlatform
+                .instance
+                .autoAPI
+                .isIndoorEnabled();
+
+            expect(result, true);
+            verify(autoViewMockApi.isIndoorEnabled(0)).called(1);
+          });
+
+          test(
+            'setIndoorEnabled sends correct value and default viewId',
+            () async {
+              await GoogleMapsNavigationPlatform.instance.autoAPI
+                  .setIndoorEnabled(enabled: true);
+
+              verify(autoViewMockApi.setIndoorEnabled(0, true)).called(1);
+            },
+          );
+
+          test('getFocusedIndoorBuilding returns converted building', () async {
+            final IndoorBuildingDto buildingDto = IndoorBuildingDto(
+              levels: <IndoorLevelDto>[
+                IndoorLevelDto(name: 'Level 1', shortName: 'L1'),
+                IndoorLevelDto(name: 'Level 2', shortName: 'L2'),
+              ],
+              activeLevelIndex: 1,
+              defaultLevelIndex: 0,
+              isUnderground: false,
+            );
+            when(
+              autoViewMockApi.getFocusedIndoorBuilding(any),
+            ).thenReturn(buildingDto);
+
+            final IndoorBuilding? building = await GoogleMapsNavigationPlatform
+                .instance
+                .autoAPI
+                .getFocusedIndoorBuilding();
+
+            expect(building, isNotNull);
+            expect(building!.levels.length, 2);
+            expect(building.activeLevelIndex, 1);
+            verify(autoViewMockApi.getFocusedIndoorBuilding(0)).called(1);
+          });
+
+          test(
+            'activateIndoorLevel sends level index and default viewId',
+            () async {
+              await GoogleMapsNavigationPlatform.instance.autoAPI
+                  .activateIndoorLevel(levelIndex: 2);
+
+              verify(autoViewMockApi.activateIndoorLevel(0, 2)).called(1);
+            },
+          );
+        });
+
         group('Custom events', () {
           test('sendCustomNavigationAutoEvent sends event and data', () async {
             await GoogleMapsNavigationPlatform.instance.autoAPI

--- a/test/google_navigation_flutter_test.dart
+++ b/test/google_navigation_flutter_test.dart
@@ -901,6 +901,34 @@ void main() {
           );
         });
 
+        test(
+          'Indoor activation rejects negative indexes at package level',
+          () async {
+            const int viewId = 1;
+            final GoogleMapViewController mapController =
+                GoogleMapViewController(viewId);
+
+            expect(
+              () => GoogleMapsNavigationPlatform.instance.viewAPI
+                  .activateIndoorLevel(viewId: viewId, levelIndex: -1),
+              throwsA(isA<AssertionError>()),
+            );
+            verifyNever(viewMockApi.activateIndoorLevel(any, any));
+
+            expect(
+              () => mapController.activateIndoorLevel(
+                const IndoorLevel(
+                  levelIndex: -1,
+                  name: 'Basement',
+                  shortName: 'B1',
+                ),
+              ),
+              throwsA(isA<AssertionError>()),
+            );
+            verifyNever(viewMockApi.activateIndoorLevel(any, any));
+          },
+        );
+
         test('Test incident reporting APIs', () async {
           const int viewId = 1;
           final GoogleNavigationViewController controller =

--- a/test/google_navigation_flutter_test.dart
+++ b/test/google_navigation_flutter_test.dart
@@ -676,6 +676,19 @@ void main() {
           when(viewMockApi.isReportIncidentButtonEnabled(any)).thenReturn(true);
           when(viewMockApi.isIncidentReportingAvailable(any)).thenReturn(true);
           when(viewMockApi.isBuildingsEnabled(any)).thenReturn(false);
+          when(viewMockApi.isIndoorEnabled(any)).thenReturn(true);
+          when(viewMockApi.isIndoorLevelPickerEnabled(any)).thenReturn(true);
+          when(viewMockApi.getFocusedIndoorBuilding(any)).thenReturn(
+            IndoorBuildingDto(
+              levels: <IndoorLevelDto>[
+                IndoorLevelDto(name: 'Level 1', shortName: 'L1'),
+                IndoorLevelDto(name: 'Level 2', shortName: 'L2'),
+              ],
+              activeLevelIndex: 1,
+              defaultLevelIndex: 0,
+              isUnderground: false,
+            ),
+          );
           when(viewMockApi.isNavigationHeaderEnabled(any)).thenReturn(true);
           when(viewMockApi.isNavigationFooterEnabled(any)).thenReturn(true);
           when(viewMockApi.isSpeedLimitIconEnabled(any)).thenReturn(true);
@@ -701,6 +714,14 @@ void main() {
           expect(await controller.isTrafficPromptsEnabled(), true);
           expect(await controller.isReportIncidentButtonEnabled(), true);
           expect(await controller.isIncidentReportingAvailable(), true);
+          expect(await controller.isIndoorEnabled(), true);
+          expect(await controller.settings.isIndoorLevelPickerEnabled(), true);
+          final IndoorBuilding? focusedIndoorBuilding = await controller
+              .getFocusedIndoorBuilding();
+          expect(focusedIndoorBuilding, isNotNull);
+          expect(focusedIndoorBuilding!.levels.length, 2);
+          expect(focusedIndoorBuilding.activeLevelIndex, 1);
+          await controller.activateIndoorLevel(focusedIndoorBuilding.levels[0]);
           expect(await controller.isNavigationHeaderEnabled(), true);
           expect(await controller.isNavigationFooterEnabled(), true);
           expect(await controller.isSpeedLimitIconEnabled(), true);
@@ -724,6 +745,10 @@ void main() {
           verify(viewMockApi.isTrafficPromptsEnabled(captureAny));
           verify(viewMockApi.isReportIncidentButtonEnabled(captureAny));
           verify(viewMockApi.isIncidentReportingAvailable(captureAny));
+          verify(viewMockApi.isIndoorEnabled(captureAny));
+          verify(viewMockApi.isIndoorLevelPickerEnabled(captureAny));
+          verify(viewMockApi.getFocusedIndoorBuilding(captureAny));
+          verify(viewMockApi.activateIndoorLevel(captureAny, captureAny));
           verify(viewMockApi.isNavigationHeaderEnabled(captureAny));
           verify(viewMockApi.isNavigationFooterEnabled(captureAny));
           verify(viewMockApi.isSpeedLimitIconEnabled(captureAny));
@@ -748,6 +773,8 @@ void main() {
           await controller.setReportIncidentButtonEnabled(true);
           await controller.showReportIncidentsPanel();
           await controller.setBuildingsEnabled(true);
+          await controller.setIndoorEnabled(true);
+          await controller.settings.setIndoorLevelPickerEnabled(true);
           await controller.setNavigationHeaderEnabled(true);
           await controller.setNavigationFooterEnabled(true);
           await controller.setSpeedLimitIconEnabled(true);
@@ -825,6 +852,16 @@ void main() {
           verify(viewMockApi.showReportIncidentsPanel(captureAny));
           verifyEnabled(
             verify(viewMockApi.setBuildingsEnabled(captureAny, captureAny)),
+            true,
+          );
+          verifyEnabled(
+            verify(viewMockApi.setIndoorEnabled(captureAny, captureAny)),
+            true,
+          );
+          verifyEnabled(
+            verify(
+              viewMockApi.setIndoorLevelPickerEnabled(captureAny, captureAny),
+            ),
             true,
           );
           verifyEnabled(

--- a/test/google_navigation_flutter_test.mocks.dart
+++ b/test/google_navigation_flutter_test.mocks.dart
@@ -798,6 +798,48 @@ class MockTestMapViewApi extends _i1.Mock implements _i3.TestMapViewApi {
   );
 
   @override
+  bool isIndoorEnabled(int? viewId) =>
+      (super.noSuchMethod(
+            Invocation.method(#isIndoorEnabled, [viewId]),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
+  void setIndoorEnabled(int? viewId, bool? enabled) => super.noSuchMethod(
+    Invocation.method(#setIndoorEnabled, [viewId, enabled]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  bool isIndoorLevelPickerEnabled(int? viewId) =>
+      (super.noSuchMethod(
+            Invocation.method(#isIndoorLevelPickerEnabled, [viewId]),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
+  void setIndoorLevelPickerEnabled(int? viewId, bool? enabled) =>
+      super.noSuchMethod(
+        Invocation.method(#setIndoorLevelPickerEnabled, [viewId, enabled]),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i2.IndoorBuildingDto? getFocusedIndoorBuilding(int? viewId) =>
+      (super.noSuchMethod(
+            Invocation.method(#getFocusedIndoorBuilding, [viewId]),
+          )
+          as _i2.IndoorBuildingDto?);
+
+  @override
+  void activateIndoorLevel(int? viewId, int? levelIndex) => super.noSuchMethod(
+    Invocation.method(#activateIndoorLevel, [viewId, levelIndex]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   _i2.CameraPositionDto getCameraPosition(int? viewId) =>
       (super.noSuchMethod(
             Invocation.method(#getCameraPosition, [viewId]),

--- a/test/google_navigation_flutter_test.mocks.dart
+++ b/test/google_navigation_flutter_test.mocks.dart
@@ -1826,29 +1826,22 @@ class MockTestAutoMapViewApi extends _i1.Mock
           as bool);
 
   @override
-  bool isIndoorEnabled(int? viewId) =>
+  bool isIndoorEnabled() =>
       (super.noSuchMethod(
-            Invocation.method(#isIndoorEnabled, [viewId]),
+            Invocation.method(#isIndoorEnabled, []),
             returnValue: false,
           )
           as bool);
 
   @override
-  void setIndoorEnabled(int? viewId, bool? enabled) => super.noSuchMethod(
-    Invocation.method(#setIndoorEnabled, [viewId, enabled]),
+  void setIndoorEnabled(bool? enabled) => super.noSuchMethod(
+    Invocation.method(#setIndoorEnabled, [enabled]),
     returnValueForMissingStub: null,
   );
 
   @override
-  _i2.IndoorBuildingDto? getFocusedIndoorBuilding(int? viewId) =>
-      (super.noSuchMethod(
-            Invocation.method(#getFocusedIndoorBuilding, [viewId]),
-          )
-          as _i2.IndoorBuildingDto?);
-
-  @override
-  void activateIndoorLevel(int? viewId, int? levelIndex) => super.noSuchMethod(
-    Invocation.method(#activateIndoorLevel, [viewId, levelIndex]),
+  void activateIndoorLevel(int? levelIndex) => super.noSuchMethod(
+    Invocation.method(#activateIndoorLevel, [levelIndex]),
     returnValueForMissingStub: null,
   );
 

--- a/test/google_navigation_flutter_test.mocks.dart
+++ b/test/google_navigation_flutter_test.mocks.dart
@@ -1826,6 +1826,33 @@ class MockTestAutoMapViewApi extends _i1.Mock
           as bool);
 
   @override
+  bool isIndoorEnabled(int? viewId) =>
+      (super.noSuchMethod(
+            Invocation.method(#isIndoorEnabled, [viewId]),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
+  void setIndoorEnabled(int? viewId, bool? enabled) => super.noSuchMethod(
+    Invocation.method(#setIndoorEnabled, [viewId, enabled]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  _i2.IndoorBuildingDto? getFocusedIndoorBuilding(int? viewId) =>
+      (super.noSuchMethod(
+            Invocation.method(#getFocusedIndoorBuilding, [viewId]),
+          )
+          as _i2.IndoorBuildingDto?);
+
+  @override
+  void activateIndoorLevel(int? viewId, int? levelIndex) => super.noSuchMethod(
+    Invocation.method(#activateIndoorLevel, [viewId, levelIndex]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void showRouteOverview() => super.noSuchMethod(
     Invocation.method(#showRouteOverview, []),
     returnValueForMissingStub: null,

--- a/test/map_view/map_view_event_api_test.dart
+++ b/test/map_view/map_view_event_api_test.dart
@@ -569,6 +569,81 @@ void main() {
       });
     });
 
+    group('Indoor Events', () {
+      test(
+        'onIndoorFocusedBuildingChanged fires and delivers correct data',
+        () async {
+          final List<IndoorFocusedBuildingChangedEvent> receivedEvents =
+              <IndoorFocusedBuildingChangedEvent>[];
+          final StreamSubscription<IndoorFocusedBuildingChangedEvent>
+          subscription = testMapViewApi
+              .getIndoorFocusedBuildingChangedEventStream(viewId: testViewId)
+              .listen(receivedEvents.add);
+
+          final IndoorBuildingDto building = IndoorBuildingDto(
+            levels: <IndoorLevelDto>[
+              IndoorLevelDto(name: 'Level 1', shortName: 'L1'),
+              IndoorLevelDto(name: 'Level 2', shortName: 'L2'),
+            ],
+            activeLevelIndex: 0,
+            defaultLevelIndex: 0,
+            isUnderground: false,
+          );
+
+          testMapViewApi.testEventApi.onIndoorFocusedBuildingChanged(
+            testViewId,
+            building,
+          );
+
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+
+          expect(receivedEvents.length, 1);
+          expect(receivedEvents[0].building, isNotNull);
+          expect(receivedEvents[0].building!.levels.length, 2);
+          expect(receivedEvents[0].building!.levels[0].shortName, 'L1');
+          expect(receivedEvents[0].building!.activeLevelIndex, 0);
+
+          await subscription.cancel();
+        },
+      );
+
+      test(
+        'onIndoorActiveLevelChanged fires and delivers correct data',
+        () async {
+          final List<IndoorActiveLevelChangedEvent> receivedEvents =
+              <IndoorActiveLevelChangedEvent>[];
+          final StreamSubscription<IndoorActiveLevelChangedEvent> subscription =
+              testMapViewApi
+                  .getIndoorActiveLevelChangedEventStream(viewId: testViewId)
+                  .listen(receivedEvents.add);
+
+          final IndoorBuildingDto building = IndoorBuildingDto(
+            levels: <IndoorLevelDto>[
+              IndoorLevelDto(name: 'B1', shortName: 'B1'),
+              IndoorLevelDto(name: 'B2', shortName: 'B2'),
+            ],
+            activeLevelIndex: 1,
+            defaultLevelIndex: 0,
+            isUnderground: true,
+          );
+
+          testMapViewApi.testEventApi.onIndoorActiveLevelChanged(
+            testViewId,
+            building,
+          );
+
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+
+          expect(receivedEvents.length, 1);
+          expect(receivedEvents[0].building, isNotNull);
+          expect(receivedEvents[0].building!.activeLevelIndex, 1);
+          expect(receivedEvents[0].building!.isUnderground, true);
+
+          await subscription.cancel();
+        },
+      );
+    });
+
     group('Camera Changed Events', () {
       test('onCameraChanged fires with move started', () async {
         final List<CameraChangedEvent> receivedEvents = <CameraChangedEvent>[];

--- a/test/map_view/map_view_widget_test.dart
+++ b/test/map_view/map_view_widget_test.dart
@@ -452,6 +452,67 @@ void main() {
       expect(myLocationButtonClicked, isTrue);
     });
 
+    testWidgets('indoor callbacks receive events', (WidgetTester tester) async {
+      IndoorBuilding? focusedBuilding;
+      IndoorBuilding? activeLevelBuilding;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: GoogleMapsMapView(
+            onViewCreated: (_) {},
+            onIndoorFocusedBuildingChanged: (IndoorBuilding? building) {
+              focusedBuilding = building;
+            },
+            onIndoorActiveLevelChanged: (IndoorBuilding? building) {
+              activeLevelBuilding = building;
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final int testViewId = getViewId();
+
+      final IndoorBuildingDto focusedDto = IndoorBuildingDto(
+        levels: <IndoorLevelDto>[
+          IndoorLevelDto(name: 'Level 1', shortName: 'L1'),
+          IndoorLevelDto(name: 'Level 2', shortName: 'L2'),
+        ],
+        activeLevelIndex: 0,
+        defaultLevelIndex: 0,
+        isUnderground: false,
+      );
+      final IndoorBuildingDto activeLevelDto = IndoorBuildingDto(
+        levels: <IndoorLevelDto>[
+          IndoorLevelDto(name: 'Level 1', shortName: 'L1'),
+          IndoorLevelDto(name: 'Level 2', shortName: 'L2'),
+        ],
+        activeLevelIndex: 1,
+        defaultLevelIndex: 0,
+        isUnderground: false,
+      );
+
+      testMapViewApi.testEventApi.onIndoorFocusedBuildingChanged(
+        testViewId,
+        focusedDto,
+      );
+      testMapViewApi.testEventApi.onIndoorActiveLevelChanged(
+        testViewId,
+        activeLevelDto,
+      );
+
+      await tester.pump();
+
+      expect(focusedBuilding, isNotNull);
+      expect(focusedBuilding!.activeLevelIndex, 0);
+      expect(focusedBuilding!.levels.length, 2);
+
+      expect(activeLevelBuilding, isNotNull);
+      expect(activeLevelBuilding!.activeLevelIndex, 1);
+      expect(activeLevelBuilding!.levels[1].shortName, 'L2');
+    });
+
     testWidgets('onCameraMove callback receives event', (
       WidgetTester tester,
     ) async {

--- a/test/messages_test.g.dart
+++ b/test/messages_test.g.dart
@@ -7221,13 +7221,13 @@ abstract class TestAutoMapViewApi {
 
   bool isNavigationUIEnabled();
 
-  bool isIndoorEnabled(int viewId);
+  bool isIndoorEnabled();
 
-  void setIndoorEnabled(int viewId, bool enabled);
+  void setIndoorEnabled(bool enabled);
 
-  IndoorBuildingDto? getFocusedIndoorBuilding(int viewId);
+  IndoorBuildingDto? getFocusedIndoorBuilding();
 
-  void activateIndoorLevel(int viewId, int levelIndex);
+  void activateIndoorLevel(int levelIndex);
 
   void showRouteOverview();
 
@@ -9697,18 +9697,8 @@ abstract class TestAutoMapViewApi {
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
               Object? message,
             ) async {
-              assert(
-                message != null,
-                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isIndoorEnabled was null.',
-              );
-              final List<Object?> args = (message as List<Object?>?)!;
-              final int? arg_viewId = (args[0] as int?);
-              assert(
-                arg_viewId != null,
-                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isIndoorEnabled was null, expected non-null int.',
-              );
               try {
-                final bool output = api.isIndoorEnabled(arg_viewId!);
+                final bool output = api.isIndoorEnabled();
                 return <Object?>[output];
               } on PlatformException catch (e) {
                 return wrapResponse(error: e);
@@ -9734,35 +9724,34 @@ abstract class TestAutoMapViewApi {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
-          Object?
-        >(pigeonVar_channel, (Object? message) async {
-          assert(
-            message != null,
-            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled was null.',
-          );
-          final List<Object?> args = (message as List<Object?>?)!;
-          final int? arg_viewId = (args[0] as int?);
-          assert(
-            arg_viewId != null,
-            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled was null, expected non-null int.',
-          );
-          final bool? arg_enabled = (args[1] as bool?);
-          assert(
-            arg_enabled != null,
-            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled was null, expected non-null bool.',
-          );
-          try {
-            api.setIndoorEnabled(arg_viewId!, arg_enabled!);
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
-          }
-        });
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final bool? arg_enabled = (args[0] as bool?);
+              assert(
+                arg_enabled != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled was null, expected non-null bool.',
+              );
+              try {
+                api.setIndoorEnabled(arg_enabled!);
+                return wrapResponse(empty: true);
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
       }
     }
     {
@@ -9780,20 +9769,9 @@ abstract class TestAutoMapViewApi {
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
               Object? message,
             ) async {
-              assert(
-                message != null,
-                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.getFocusedIndoorBuilding was null.',
-              );
-              final List<Object?> args = (message as List<Object?>?)!;
-              final int? arg_viewId = (args[0] as int?);
-              assert(
-                arg_viewId != null,
-                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.getFocusedIndoorBuilding was null, expected non-null int.',
-              );
               try {
-                final IndoorBuildingDto? output = api.getFocusedIndoorBuilding(
-                  arg_viewId!,
-                );
+                final IndoorBuildingDto? output = api
+                    .getFocusedIndoorBuilding();
                 return <Object?>[output];
               } on PlatformException catch (e) {
                 return wrapResponse(error: e);
@@ -9819,35 +9797,34 @@ abstract class TestAutoMapViewApi {
         _testBinaryMessengerBinding!.defaultBinaryMessenger
             .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
-          Object?
-        >(pigeonVar_channel, (Object? message) async {
-          assert(
-            message != null,
-            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel was null.',
-          );
-          final List<Object?> args = (message as List<Object?>?)!;
-          final int? arg_viewId = (args[0] as int?);
-          assert(
-            arg_viewId != null,
-            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel was null, expected non-null int.',
-          );
-          final int? arg_levelIndex = (args[1] as int?);
-          assert(
-            arg_levelIndex != null,
-            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel was null, expected non-null int.',
-          );
-          try {
-            api.activateIndoorLevel(arg_viewId!, arg_levelIndex!);
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
-          }
-        });
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final int? arg_levelIndex = (args[0] as int?);
+              assert(
+                arg_levelIndex != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel was null, expected non-null int.',
+              );
+              try {
+                api.activateIndoorLevel(arg_levelIndex!);
+                return wrapResponse(empty: true);
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
       }
     }
     {

--- a/test/messages_test.g.dart
+++ b/test/messages_test.g.dart
@@ -143,110 +143,116 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is PointOfInterestDto) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is PolygonDto) {
+    } else if (value is IndoorLevelDto) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is PolygonOptionsDto) {
+    } else if (value is IndoorBuildingDto) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is PolygonHoleDto) {
+    } else if (value is PolygonDto) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is StyleSpanStrokeStyleDto) {
+    } else if (value is PolygonOptionsDto) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is StyleSpanDto) {
+    } else if (value is PolygonHoleDto) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is PolylineDto) {
+    } else if (value is StyleSpanStrokeStyleDto) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is PatternItemDto) {
+    } else if (value is StyleSpanDto) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is PolylineOptionsDto) {
+    } else if (value is PolylineDto) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is CircleDto) {
+    } else if (value is PatternItemDto) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is CircleOptionsDto) {
+    } else if (value is PolylineOptionsDto) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is MapPaddingDto) {
+    } else if (value is CircleDto) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is RouteTokenOptionsDto) {
+    } else if (value is CircleOptionsDto) {
       buffer.putUint8(177);
       writeValue(buffer, value.encode());
-    } else if (value is DestinationsDto) {
+    } else if (value is MapPaddingDto) {
       buffer.putUint8(178);
       writeValue(buffer, value.encode());
-    } else if (value is RoutingOptionsDto) {
+    } else if (value is RouteTokenOptionsDto) {
       buffer.putUint8(179);
       writeValue(buffer, value.encode());
-    } else if (value is NavigationDisplayOptionsDto) {
+    } else if (value is DestinationsDto) {
       buffer.putUint8(180);
       writeValue(buffer, value.encode());
-    } else if (value is NavigationWaypointDto) {
+    } else if (value is RoutingOptionsDto) {
       buffer.putUint8(181);
       writeValue(buffer, value.encode());
-    } else if (value is ContinueToNextDestinationResponseDto) {
+    } else if (value is NavigationDisplayOptionsDto) {
       buffer.putUint8(182);
       writeValue(buffer, value.encode());
-    } else if (value is NavigationTimeAndDistanceDto) {
+    } else if (value is NavigationWaypointDto) {
       buffer.putUint8(183);
       writeValue(buffer, value.encode());
-    } else if (value is NavigationAudioGuidanceSettingsDto) {
+    } else if (value is ContinueToNextDestinationResponseDto) {
       buffer.putUint8(184);
       writeValue(buffer, value.encode());
-    } else if (value is SimulationOptionsDto) {
+    } else if (value is NavigationTimeAndDistanceDto) {
       buffer.putUint8(185);
       writeValue(buffer, value.encode());
-    } else if (value is LatLngDto) {
+    } else if (value is NavigationAudioGuidanceSettingsDto) {
       buffer.putUint8(186);
       writeValue(buffer, value.encode());
-    } else if (value is LatLngBoundsDto) {
+    } else if (value is SimulationOptionsDto) {
       buffer.putUint8(187);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedingUpdatedEventDto) {
+    } else if (value is LatLngDto) {
       buffer.putUint8(188);
       writeValue(buffer, value.encode());
-    } else if (value is GpsAvailabilityChangeEventDto) {
+    } else if (value is LatLngBoundsDto) {
       buffer.putUint8(189);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedAlertOptionsThresholdPercentageDto) {
+    } else if (value is SpeedingUpdatedEventDto) {
       buffer.putUint8(190);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedAlertOptionsDto) {
+    } else if (value is GpsAvailabilityChangeEventDto) {
       buffer.putUint8(191);
       writeValue(buffer, value.encode());
-    } else if (value is RouteSegmentTrafficDataRoadStretchRenderingDataDto) {
+    } else if (value is SpeedAlertOptionsThresholdPercentageDto) {
       buffer.putUint8(192);
       writeValue(buffer, value.encode());
-    } else if (value is RouteSegmentTrafficDataDto) {
+    } else if (value is SpeedAlertOptionsDto) {
       buffer.putUint8(193);
       writeValue(buffer, value.encode());
-    } else if (value is RouteSegmentDto) {
+    } else if (value is RouteSegmentTrafficDataRoadStretchRenderingDataDto) {
       buffer.putUint8(194);
       writeValue(buffer, value.encode());
-    } else if (value is LaneDirectionDto) {
+    } else if (value is RouteSegmentTrafficDataDto) {
       buffer.putUint8(195);
       writeValue(buffer, value.encode());
-    } else if (value is LaneDto) {
+    } else if (value is RouteSegmentDto) {
       buffer.putUint8(196);
       writeValue(buffer, value.encode());
-    } else if (value is StepInfoDto) {
+    } else if (value is LaneDirectionDto) {
       buffer.putUint8(197);
       writeValue(buffer, value.encode());
-    } else if (value is NavInfoDto) {
+    } else if (value is LaneDto) {
       buffer.putUint8(198);
       writeValue(buffer, value.encode());
-    } else if (value is TermsAndConditionsUIParamsDto) {
+    } else if (value is StepInfoDto) {
       buffer.putUint8(199);
       writeValue(buffer, value.encode());
-    } else if (value is StepImageGenerationOptionsDto) {
+    } else if (value is NavInfoDto) {
       buffer.putUint8(200);
+      writeValue(buffer, value.encode());
+    } else if (value is TermsAndConditionsUIParamsDto) {
+      buffer.putUint8(201);
+      writeValue(buffer, value.encode());
+    } else if (value is StepImageGenerationOptionsDto) {
+      buffer.putUint8(202);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -364,78 +370,82 @@ class _PigeonCodec extends StandardMessageCodec {
       case 165:
         return PointOfInterestDto.decode(readValue(buffer)!);
       case 166:
-        return PolygonDto.decode(readValue(buffer)!);
+        return IndoorLevelDto.decode(readValue(buffer)!);
       case 167:
-        return PolygonOptionsDto.decode(readValue(buffer)!);
+        return IndoorBuildingDto.decode(readValue(buffer)!);
       case 168:
-        return PolygonHoleDto.decode(readValue(buffer)!);
+        return PolygonDto.decode(readValue(buffer)!);
       case 169:
-        return StyleSpanStrokeStyleDto.decode(readValue(buffer)!);
+        return PolygonOptionsDto.decode(readValue(buffer)!);
       case 170:
-        return StyleSpanDto.decode(readValue(buffer)!);
+        return PolygonHoleDto.decode(readValue(buffer)!);
       case 171:
-        return PolylineDto.decode(readValue(buffer)!);
+        return StyleSpanStrokeStyleDto.decode(readValue(buffer)!);
       case 172:
-        return PatternItemDto.decode(readValue(buffer)!);
+        return StyleSpanDto.decode(readValue(buffer)!);
       case 173:
-        return PolylineOptionsDto.decode(readValue(buffer)!);
+        return PolylineDto.decode(readValue(buffer)!);
       case 174:
-        return CircleDto.decode(readValue(buffer)!);
+        return PatternItemDto.decode(readValue(buffer)!);
       case 175:
-        return CircleOptionsDto.decode(readValue(buffer)!);
+        return PolylineOptionsDto.decode(readValue(buffer)!);
       case 176:
-        return MapPaddingDto.decode(readValue(buffer)!);
+        return CircleDto.decode(readValue(buffer)!);
       case 177:
-        return RouteTokenOptionsDto.decode(readValue(buffer)!);
+        return CircleOptionsDto.decode(readValue(buffer)!);
       case 178:
-        return DestinationsDto.decode(readValue(buffer)!);
+        return MapPaddingDto.decode(readValue(buffer)!);
       case 179:
-        return RoutingOptionsDto.decode(readValue(buffer)!);
+        return RouteTokenOptionsDto.decode(readValue(buffer)!);
       case 180:
-        return NavigationDisplayOptionsDto.decode(readValue(buffer)!);
+        return DestinationsDto.decode(readValue(buffer)!);
       case 181:
-        return NavigationWaypointDto.decode(readValue(buffer)!);
+        return RoutingOptionsDto.decode(readValue(buffer)!);
       case 182:
-        return ContinueToNextDestinationResponseDto.decode(readValue(buffer)!);
+        return NavigationDisplayOptionsDto.decode(readValue(buffer)!);
       case 183:
-        return NavigationTimeAndDistanceDto.decode(readValue(buffer)!);
+        return NavigationWaypointDto.decode(readValue(buffer)!);
       case 184:
-        return NavigationAudioGuidanceSettingsDto.decode(readValue(buffer)!);
+        return ContinueToNextDestinationResponseDto.decode(readValue(buffer)!);
       case 185:
-        return SimulationOptionsDto.decode(readValue(buffer)!);
+        return NavigationTimeAndDistanceDto.decode(readValue(buffer)!);
       case 186:
-        return LatLngDto.decode(readValue(buffer)!);
+        return NavigationAudioGuidanceSettingsDto.decode(readValue(buffer)!);
       case 187:
-        return LatLngBoundsDto.decode(readValue(buffer)!);
+        return SimulationOptionsDto.decode(readValue(buffer)!);
       case 188:
-        return SpeedingUpdatedEventDto.decode(readValue(buffer)!);
+        return LatLngDto.decode(readValue(buffer)!);
       case 189:
-        return GpsAvailabilityChangeEventDto.decode(readValue(buffer)!);
+        return LatLngBoundsDto.decode(readValue(buffer)!);
       case 190:
+        return SpeedingUpdatedEventDto.decode(readValue(buffer)!);
+      case 191:
+        return GpsAvailabilityChangeEventDto.decode(readValue(buffer)!);
+      case 192:
         return SpeedAlertOptionsThresholdPercentageDto.decode(
           readValue(buffer)!,
         );
-      case 191:
+      case 193:
         return SpeedAlertOptionsDto.decode(readValue(buffer)!);
-      case 192:
+      case 194:
         return RouteSegmentTrafficDataRoadStretchRenderingDataDto.decode(
           readValue(buffer)!,
         );
-      case 193:
-        return RouteSegmentTrafficDataDto.decode(readValue(buffer)!);
-      case 194:
-        return RouteSegmentDto.decode(readValue(buffer)!);
       case 195:
-        return LaneDirectionDto.decode(readValue(buffer)!);
+        return RouteSegmentTrafficDataDto.decode(readValue(buffer)!);
       case 196:
-        return LaneDto.decode(readValue(buffer)!);
+        return RouteSegmentDto.decode(readValue(buffer)!);
       case 197:
-        return StepInfoDto.decode(readValue(buffer)!);
+        return LaneDirectionDto.decode(readValue(buffer)!);
       case 198:
-        return NavInfoDto.decode(readValue(buffer)!);
+        return LaneDto.decode(readValue(buffer)!);
       case 199:
-        return TermsAndConditionsUIParamsDto.decode(readValue(buffer)!);
+        return StepInfoDto.decode(readValue(buffer)!);
       case 200:
+        return NavInfoDto.decode(readValue(buffer)!);
+      case 201:
+        return TermsAndConditionsUIParamsDto.decode(readValue(buffer)!);
+      case 202:
         return StepImageGenerationOptionsDto.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -553,6 +563,21 @@ abstract class TestMapViewApi {
   bool isBuildingsEnabled(int viewId);
 
   void setBuildingsEnabled(int viewId, bool enabled);
+
+  bool isIndoorEnabled(int viewId);
+
+  void setIndoorEnabled(int viewId, bool enabled);
+
+  bool isIndoorLevelPickerEnabled(int viewId);
+
+  void setIndoorLevelPickerEnabled(int viewId, bool enabled);
+
+  IndoorBuildingDto? getFocusedIndoorBuilding(int viewId);
+
+  /// Activates the indoor level at [levelIndex] within the currently focused
+  /// indoor building. Throws if no building is focused or the index is out of
+  /// range.
+  void activateIndoorLevel(int viewId, int levelIndex);
 
   CameraPositionDto getCameraPosition(int viewId);
 
@@ -2912,6 +2937,257 @@ abstract class TestMapViewApi {
           );
           try {
             api.setBuildingsEnabled(arg_viewId!, arg_enabled!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorEnabled$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorEnabled was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final int? arg_viewId = (args[0] as int?);
+              assert(
+                arg_viewId != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorEnabled was null, expected non-null int.',
+              );
+              try {
+                final bool output = api.isIndoorEnabled(arg_viewId!);
+                return <Object?>[output];
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorEnabled$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
+          Object?
+        >(pigeonVar_channel, (Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorEnabled was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_viewId = (args[0] as int?);
+          assert(
+            arg_viewId != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorEnabled was null, expected non-null int.',
+          );
+          final bool? arg_enabled = (args[1] as bool?);
+          assert(
+            arg_enabled != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorEnabled was null, expected non-null bool.',
+          );
+          try {
+            api.setIndoorEnabled(arg_viewId!, arg_enabled!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorLevelPickerEnabled$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorLevelPickerEnabled was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final int? arg_viewId = (args[0] as int?);
+              assert(
+                arg_viewId != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.isIndoorLevelPickerEnabled was null, expected non-null int.',
+              );
+              try {
+                final bool output = api.isIndoorLevelPickerEnabled(arg_viewId!);
+                return <Object?>[output];
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorLevelPickerEnabled$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
+          Object?
+        >(pigeonVar_channel, (Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorLevelPickerEnabled was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_viewId = (args[0] as int?);
+          assert(
+            arg_viewId != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorLevelPickerEnabled was null, expected non-null int.',
+          );
+          final bool? arg_enabled = (args[1] as bool?);
+          assert(
+            arg_enabled != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.setIndoorLevelPickerEnabled was null, expected non-null bool.',
+          );
+          try {
+            api.setIndoorLevelPickerEnabled(arg_viewId!, arg_enabled!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.getFocusedIndoorBuilding$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.getFocusedIndoorBuilding was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final int? arg_viewId = (args[0] as int?);
+              assert(
+                arg_viewId != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.getFocusedIndoorBuilding was null, expected non-null int.',
+              );
+              try {
+                final IndoorBuildingDto? output = api.getFocusedIndoorBuilding(
+                  arg_viewId!,
+                );
+                return <Object?>[output];
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.MapViewApi.activateIndoorLevel$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
+          Object?
+        >(pigeonVar_channel, (Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.activateIndoorLevel was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_viewId = (args[0] as int?);
+          assert(
+            arg_viewId != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.activateIndoorLevel was null, expected non-null int.',
+          );
+          final int? arg_levelIndex = (args[1] as int?);
+          assert(
+            arg_levelIndex != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.MapViewApi.activateIndoorLevel was null, expected non-null int.',
+          );
+          try {
+            api.activateIndoorLevel(arg_viewId!, arg_levelIndex!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
@@ -6945,6 +7221,14 @@ abstract class TestAutoMapViewApi {
 
   bool isNavigationUIEnabled();
 
+  bool isIndoorEnabled(int viewId);
+
+  void setIndoorEnabled(int viewId, bool enabled);
+
+  IndoorBuildingDto? getFocusedIndoorBuilding(int viewId);
+
+  void activateIndoorLevel(int viewId, int levelIndex);
+
   void showRouteOverview();
 
   List<MarkerDto> getMarkers();
@@ -9396,6 +9680,174 @@ abstract class TestAutoMapViewApi {
                 );
               }
             });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isIndoorEnabled$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isIndoorEnabled was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final int? arg_viewId = (args[0] as int?);
+              assert(
+                arg_viewId != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.isIndoorEnabled was null, expected non-null int.',
+              );
+              try {
+                final bool output = api.isIndoorEnabled(arg_viewId!);
+                return <Object?>[output];
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
+          Object?
+        >(pigeonVar_channel, (Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_viewId = (args[0] as int?);
+          assert(
+            arg_viewId != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled was null, expected non-null int.',
+          );
+          final bool? arg_enabled = (args[1] as bool?);
+          assert(
+            arg_enabled != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.setIndoorEnabled was null, expected non-null bool.',
+          );
+          try {
+            api.setIndoorEnabled(arg_viewId!, arg_enabled!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.getFocusedIndoorBuilding$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, (
+              Object? message,
+            ) async {
+              assert(
+                message != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.getFocusedIndoorBuilding was null.',
+              );
+              final List<Object?> args = (message as List<Object?>?)!;
+              final int? arg_viewId = (args[0] as int?);
+              assert(
+                arg_viewId != null,
+                'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.getFocusedIndoorBuilding was null, expected non-null int.',
+              );
+              try {
+                final IndoorBuildingDto? output = api.getFocusedIndoorBuilding(
+                  arg_viewId!,
+                );
+                return <Object?>[output];
+              } on PlatformException catch (e) {
+                return wrapResponse(error: e);
+              } catch (e) {
+                return wrapResponse(
+                  error: PlatformException(
+                    code: 'error',
+                    message: e.toString(),
+                  ),
+                );
+              }
+            });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?>
+      pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<
+          Object?
+        >(pigeonVar_channel, (Object? message) async {
+          assert(
+            message != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel was null.',
+          );
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_viewId = (args[0] as int?);
+          assert(
+            arg_viewId != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel was null, expected non-null int.',
+          );
+          final int? arg_levelIndex = (args[1] as int?);
+          assert(
+            arg_levelIndex != null,
+            'Argument for dev.flutter.pigeon.google_navigation_flutter.AutoMapViewApi.activateIndoorLevel was null, expected non-null int.',
+          );
+          try {
+            api.activateIndoorLevel(arg_viewId!, arg_levelIndex!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
       }
     }
     {

--- a/test/types/navigation_types_test.dart
+++ b/test/types/navigation_types_test.dart
@@ -761,4 +761,56 @@ void main() {
       expect(event.pointOfInterest.latLng.longitude, -122.083922);
     });
   });
+
+  group('Indoor building tests', () {
+    test('tests IndoorBuilding conversion from DTO', () {
+      final IndoorBuildingDto dto = IndoorBuildingDto(
+        levels: <IndoorLevelDto>[
+          IndoorLevelDto(name: 'Level 1', shortName: 'L1'),
+          IndoorLevelDto(name: 'Level 2', shortName: 'L2'),
+        ],
+        activeLevelIndex: 1,
+        defaultLevelIndex: 0,
+        isUnderground: false,
+      );
+
+      final IndoorBuilding building = dto.toIndoorBuilding();
+
+      expect(building.levels.length, 2);
+      expect(building.levels[0].levelIndex, 0);
+      expect(building.levels[0].name, 'Level 1');
+      expect(building.levels[0].shortName, 'L1');
+      expect(building.levels[1].levelIndex, 1);
+      expect(building.levels[1].name, 'Level 2');
+      expect(building.levels[1].shortName, 'L2');
+      expect(building.activeLevelIndex, 1);
+      expect(building.defaultLevelIndex, 0);
+      expect(building.isUnderground, false);
+    });
+
+    test('tests IndoorBuilding equality', () {
+      final IndoorBuilding building1 = IndoorBuilding(
+        levels: const <IndoorLevel>[
+          IndoorLevel(levelIndex: 0, name: 'Level 1', shortName: 'L1'),
+          IndoorLevel(levelIndex: 1, name: 'Level 2', shortName: 'L2'),
+        ],
+        activeLevelIndex: 1,
+        defaultLevelIndex: 0,
+        isUnderground: false,
+      );
+
+      final IndoorBuilding building2 = IndoorBuilding(
+        levels: const <IndoorLevel>[
+          IndoorLevel(levelIndex: 0, name: 'Level 1', shortName: 'L1'),
+          IndoorLevel(levelIndex: 1, name: 'Level 2', shortName: 'L2'),
+        ],
+        activeLevelIndex: 1,
+        defaultLevelIndex: 0,
+        isUnderground: false,
+      );
+
+      expect(building1, building2);
+      expect(building1.hashCode, building2.hashCode);
+    });
+  });
 }

--- a/test/types/platform_exception_test.dart
+++ b/test/types/platform_exception_test.dart
@@ -149,6 +149,48 @@ void main() {
       expect(typed.message, 'Failed to decode image');
     });
 
+    test(
+      'converts indoorLevelActivationFailed (no focused building) to IndoorLevelActivationException',
+      () {
+        final PlatformException exception = PlatformException(
+          code: IndoorLevelActivationException.platformCode,
+          message: 'No indoor building is currently focused',
+        );
+
+        final Object result = convertPlatformException(
+          exception,
+          testStackTrace,
+        );
+
+        expect(result, isA<IndoorLevelActivationException>());
+        final IndoorLevelActivationException typed =
+            result as IndoorLevelActivationException;
+        expect(typed.code, IndoorLevelActivationException.platformCode);
+        expect(typed.message, 'No indoor building is currently focused');
+      },
+    );
+
+    test(
+      'converts indoorLevelActivationFailed (index out of range) to IndoorLevelActivationException',
+      () {
+        final PlatformException exception = PlatformException(
+          code: IndoorLevelActivationException.platformCode,
+          message: 'Level index 10 is out of range',
+        );
+
+        final Object result = convertPlatformException(
+          exception,
+          testStackTrace,
+        );
+
+        expect(result, isA<IndoorLevelActivationException>());
+        final IndoorLevelActivationException typed =
+            result as IndoorLevelActivationException;
+        expect(typed.code, IndoorLevelActivationException.platformCode);
+        expect(typed.message, 'Level index 10 is out of range');
+      },
+    );
+
     group('notSupported code', () {
       test('converts to UnsupportedError with message from exception', () {
         final PlatformException exception = PlatformException(
@@ -413,6 +455,12 @@ void main() {
                   message: 'test',
                 ),
               ),
+              IndoorLevelActivationException(
+                exception: PlatformException(
+                  code: IndoorLevelActivationException.platformCode,
+                  message: 'test',
+                ),
+              ),
             ];
 
         for (final GoogleMapsNavigationPlatformException exception
@@ -472,11 +520,12 @@ void main() {
         MaxZoomRangeException.platformCode,
         MinZoomRangeException.platformCode,
         ImageDecodingFailedException.platformCode,
+        IndoorLevelActivationException.platformCode,
         unsupportedPlatformCode,
       };
 
       // If all codes are unique, the set size equals the number of codes
-      expect(codes.length, 10);
+      expect(codes.length, 11);
     });
   });
 }


### PR DESCRIPTION
This PR adds app-facing indoor map controls to Flutter map/navigation APIs and updates platform integrations so developers can configure indoor behavior consistently on Android and iOS.

- Add indoor map enable/disable API for map-facing controllers
- Add indoor level picker enable/disable API
- Add focused indoor building and indoor level activation APIs
- Update example apps to demonstrate indoor controls and level switching

Closes #701

<img width="350" alt="Indoor controls example app" src="https://github.com/user-attachments/assets/6f2d0d4e-67db-4b99-9db2-9c95e3f3b333" />

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/