### PR TITLE
feat: support custom Flutter messages to auto views

### DIFF
--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/AndroidAutoBaseScreen.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/AndroidAutoBaseScreen.kt
@@ -218,8 +218,10 @@ open class AndroidAutoBaseScreen(carContext: CarContext) :
             viewRegistry,
             imageRegistry,
             navigationView,
-            navigationView,
             googleMap,
+            onFlutterCustomNavigationAutoEvent = { event, data ->
+              onCustomNavigationAutoEventFromFlutter(event, data)
+            },
           )
 
         googleMap.setOnIndoorStateChangeListener(

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoMapView.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoMapView.kt
@@ -17,7 +17,6 @@
 package com.google.maps.flutter.navigation
 
 import android.view.View
-import android.view.ViewGroup
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.libraries.navigation.NavigationView
 
@@ -27,12 +26,12 @@ internal constructor(
   viewRegistry: GoogleMapsViewRegistry,
   imageRegistry: ImageRegistry,
   override val navigationView: NavigationView,
-  private val viewGroup: ViewGroup,
   map: GoogleMap,
+  private val onFlutterCustomNavigationAutoEvent: (String, Any) -> Unit,
 ) : GoogleMapsBaseNavigationView(null, mapOptions, null, imageRegistry) {
 
   override fun getView(): View {
-    return viewGroup
+    return navigationView
   }
 
   init {
@@ -58,5 +57,9 @@ internal constructor(
 
   override fun onPause(): Boolean {
     return super.onPause()
+  }
+
+  fun onCustomNavigationAutoEventFromFlutter(event: String, data: Any) {
+    onFlutterCustomNavigationAutoEvent(event, data)
   }
 }

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoViewMessageHandler.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoViewMessageHandler.kt
@@ -22,13 +22,9 @@ import android.content.res.Resources
 class GoogleMapsAutoViewMessageHandler(private val viewRegistry: GoogleMapsViewRegistry) :
   AutoMapViewApi {
 
-  private fun getView(): GoogleMapsBaseNavigationView {
-    val view = viewRegistry.getAndroidAutoView()
-    if (view != null) {
-      return view
-    } else {
-      throw FlutterError("viewNotFound", "No valid android auto view found")
-    }
+  private fun getView(): GoogleMapsAutoMapView {
+    return viewRegistry.getAndroidAutoView()
+      ?: throw FlutterError("viewNotFound", "No valid android auto view found")
   }
 
   override fun setAutoMapOptions(mapOptions: AutoMapOptionsDto) {
@@ -505,12 +501,6 @@ class GoogleMapsAutoViewMessageHandler(private val viewRegistry: GoogleMapsViewR
   }
 
   override fun sendCustomNavigationAutoEvent(event: String, data: Any) {
-    // This method receives custom events from Flutter.
-    // The implementation is left empty by design, as developers should handle
-    // custom events in their AndroidAutoBaseScreen subclass by overriding
-    // onCustomNavigationAutoEventFromFlutter method.
-    //
-    // Note: If you need to handle events here, you would need to maintain a reference
-    // to your AndroidAutoBaseScreen instance and call a method on it.
+    getView().onCustomNavigationAutoEventFromFlutter(event, data)
   }
 }

--- a/example/android/app/src/main/kotlin/com/google/maps/flutter/navigation_example/SampleAndroidAutoScreen.kt
+++ b/example/android/app/src/main/kotlin/com/google/maps/flutter/navigation_example/SampleAndroidAutoScreen.kt
@@ -19,6 +19,7 @@ package com.google.maps.flutter.navigation_example
 import android.annotation.SuppressLint
 import android.util.Log
 import androidx.car.app.CarContext
+import androidx.car.app.CarToast
 import androidx.car.app.model.Action
 import androidx.car.app.model.ActionStrip
 import androidx.car.app.model.CarIcon
@@ -113,8 +114,15 @@ class SampleAndroidAutoScreen(carContext: CarContext): AndroidAutoBaseScreen(car
 
     // Example of handling custom events from Flutter
     override fun onCustomNavigationAutoEventFromFlutter(event: String, data: Any) {
-        super.onCustomNavigationAutoEventFromFlutter(event, data)
         Log.d("SampleAndroidAutoScreen", "Received custom event from Flutter: event=$event, data=$data")
+
+        val message = (data as? Map<*, *>)?.get("message")?.toString()?.take(120)
+            ?: "No message"
+        CarToast.makeText(
+            carContext,
+            message,
+            CarToast.LENGTH_SHORT,
+        ).show()
     }
 
     // Example of providing custom map options from native code

--- a/example/ios/Runner/CarSceneDelegate.swift
+++ b/example/ios/Runner/CarSceneDelegate.swift
@@ -32,13 +32,22 @@ class CarSceneDelegate: BaseCarSceneDelegate {
         zoomLevel: nil
       )
     }
-    template.leadingNavigationBarButtons = [customEventButton, recenterButton]
+
+    let navView = getNavView()
+    var leadingButtons = [customEventButton]
+    if (navView?.isAttachedToSession ?? false) && (navView?.isNavigationUIEnabled() ?? false) {
+      leadingButtons.append(recenterButton)
+    }
+    template.leadingNavigationBarButtons = leadingButtons
     return template
   }
 
   // Example of handling custom events from Flutter
   override func onCustomNavigationAutoEventFromFlutter(event: String, data: Any) {
     NSLog("CarSceneDelegate: Received custom event from Flutter: event=\(event), data=\(data)")
+
+    let message = (data as? [String: Any])?["message"] as? String ?? "No message"
+    showCarPlayMessage(String(message.prefix(120)))
   }
 
   // Example of providing custom map options from native code
@@ -83,5 +92,33 @@ class CarSceneDelegate: BaseCarSceneDelegate {
     //   }
     //   mapTemplate?.leadingNavigationBarButtons = [customEventButton, recenterButton]
     // }
+  }
+
+  override func onNavigationUIEnabledChanged(isEnabled: Bool) {
+    refreshTemplate()
+  }
+
+  override func onSessionAttachmentChanged(isAttachedToSession: Bool) {
+    refreshTemplate()
+  }
+
+  private func showCarPlayMessage(_ message: String) {
+    DispatchQueue.main.async {
+      guard
+        let interfaceController = UIApplication.shared.connectedScenes
+          .compactMap({ $0 as? CPTemplateApplicationScene })
+          .first?
+          .interfaceController
+      else {
+        return
+      }
+
+      let alertAction = CPAlertAction(title: "OK", style: .default) { _ in
+        interfaceController.dismissTemplate(animated: true, completion: nil)
+      }
+      let alert = CPAlertTemplate(titleVariants: [message], actions: [alertAction])
+
+      interfaceController.presentTemplate(alert, animated: true, completion: nil)
+    }
   }
 }

--- a/example/lib/pages/navigation.dart
+++ b/example/lib/pages/navigation.dart
@@ -255,13 +255,6 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
             ? "Traffic prompt is now visible on auto screen"
             : "Traffic prompt is now hidden on auto screen",
       );
-
-      // Example: Send a custom event back to native to adjust UI
-      _autoViewController
-          .sendCustomNavigationAutoEvent('PromptVisibilityChanged', {
-            'promptVisible': event.promptVisible,
-            'timestamp': DateTime.now().millisecondsSinceEpoch,
-          });
     });
   }
 
@@ -373,6 +366,21 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
       ),
     );
     await _autoViewController.addMarkers([markerOptions]);
+  }
+
+  Future<void> _sendCustomEventForAuto() async {
+    final Map<String, Object> data = <String, Object>{
+      'message': 'Hello from Flutter!',
+      'timestamp': DateTime.now().millisecondsSinceEpoch,
+    };
+
+    await _autoViewController.sendCustomNavigationAutoEvent(
+      'ManualAutoViewEvent',
+      data,
+    );
+
+    if (!mounted) return;
+    _showMessage('Sent custom event to the auto view');
   }
 
   Future<void> _syncAutoNavigationUI() async {
@@ -2435,6 +2443,10 @@ class _NavigationPageState extends ExamplePageState<NavigationPage> {
               ElevatedButton(
                 onPressed: () => _addMarkerForAuto(),
                 child: const Text('Add marker'),
+              ),
+              ElevatedButton(
+                onPressed: () => _sendCustomEventForAuto(),
+                child: const Text('Send custom event'),
               ),
               ElevatedButton(
                 onPressed: () => _autoViewController.showRouteOverview(),

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/BaseCarSceneDelegate.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/BaseCarSceneDelegate.swift
@@ -82,6 +82,14 @@ open class BaseCarSceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate
     return template
   }
 
+  /// Rebuilds and applies the current CarPlay map template.
+  public func refreshTemplate(animated: Bool = true) {
+    mapTemplate = getTemplate()
+    mapTemplate?.mapDelegate = self
+    guard let mapTemplate else { return }
+    interfaceController?.setRootTemplate(mapTemplate, animated: animated) { _, _ in }
+  }
+
   open func templateApplicationScene(
     _ templateApplicationScene: CPTemplateApplicationScene,
     didDisconnect interfaceController: CPInterfaceController,
@@ -154,6 +162,21 @@ open class BaseCarSceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate
 
         self.navView?.indoorActiveLevelChangedCallback = { [weak self] building in
           self?.sendIndoorActiveLevelChangedEvent(building: building)
+        }
+
+        // Set up custom event callback from Flutter to allow override
+        self.navView?.customNavigationAutoEventFromFlutterCallback = { [weak self] event, data in
+          self?.onCustomNavigationAutoEventFromFlutter(event: event, data: data)
+        }
+
+        // Set up navigation UI enabled callback to allow override
+        self.navView?.navigationUIEnabledChangedCallback = { [weak self] isEnabled in
+          self?.onNavigationUIEnabledChanged(isEnabled: isEnabled)
+        }
+
+        // Set up session attachment callback to allow override
+        self.navView?.sessionAttachmentChangedCallback = { [weak self] isAttachedToSession in
+          self?.onSessionAttachmentChanged(isAttachedToSession: isAttachedToSession)
         }
 
         self.navView?.setNavigationHeaderEnabled(false)
@@ -274,6 +297,20 @@ open class BaseCarSceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate
   open func onCustomNavigationAutoEventFromFlutter(event: String, data: Any) {
     // Default implementation does nothing
     // Subclasses can override to handle custom events
+  }
+
+  // Called when CarPlay navigation UI enabled state changes.
+  // Override this method in your CarSceneDelegate subclass to handle the state change.
+  open func onNavigationUIEnabledChanged(isEnabled: Bool) {
+    // Default implementation does nothing
+    // Subclasses can override to handle state changes
+  }
+
+  // Called when CarPlay navigation view attaches to or detaches from a navigation session.
+  // Override this method in your CarSceneDelegate subclass to handle the state change.
+  open func onSessionAttachmentChanged(isAttachedToSession: Bool) {
+    // Default implementation does nothing
+    // Subclasses can override to handle state changes
   }
 
   func sendAutoScreenAvailabilityChangedEvent(isAvailable: Bool) {

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsAutoViewMessageHandler.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsAutoViewMessageHandler.swift
@@ -591,12 +591,6 @@ class GoogleMapsAutoViewMessageHandler: AutoMapViewApi {
   }
 
   func sendCustomNavigationAutoEvent(event: String, data: Any) throws {
-    // This method receives custom events from Flutter.
-    // The implementation is left empty by design, as developers should handle
-    // custom events in their BaseCarSceneDelegate subclass by overriding
-    // onCustomNavigationAutoEventFromFlutter method.
-    //
-    // Note: If you need to handle events here, you would need to maintain a reference
-    // to your CarSceneDelegate instance and call a method on it.
+    try getView().sendCustomNavigationAutoEventFromFlutter(event: event, data: data)
   }
 }

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationView.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationView.swift
@@ -47,7 +47,7 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
   private var _imageRegistry: ImageRegistry
   private var _consumeMyLocationButtonClickEventsEnabled: Bool = false
   private var _listenCameraChanges = false
-  var isAttachedToSession: Bool = false
+  public private(set) var isAttachedToSession: Bool = false
   private let _isCarPlayView: Bool
 
   // As prompt visibility settings is handled by the navigator, value is
@@ -65,6 +65,18 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
   // Callbacks for CarPlay views to handle indoor state changes.
   var indoorFocusedBuildingChangedCallback: ((IndoorBuildingDto?) -> Void)?
   var indoorActiveLevelChangedCallback: ((IndoorBuildingDto?) -> Void)?
+
+  // Callback for CarPlay views to handle custom events sent from Flutter
+  // This allows BaseCarSceneDelegate to intercept and handle the event
+  var customNavigationAutoEventFromFlutterCallback: ((String, Any) -> Void)?
+
+  // Callback for CarPlay views to handle navigation UI state changes
+  // This allows BaseCarSceneDelegate subclasses to react when UI state changes
+  var navigationUIEnabledChangedCallback: ((Bool) -> Void)?
+
+  // Callback for CarPlay views to handle session attachment state changes
+  // This allows BaseCarSceneDelegate subclasses to react when session attachment changes
+  var sessionAttachmentChangedCallback: ((Bool) -> Void)?
 
   public func view() -> UIView {
     _mapView
@@ -569,7 +581,12 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
     session.navigator?.shouldDisplayPrompts = _isTrafficPromptsEnabled
 
     _mapView.navigationUIDelegate = self
+    let wasAttachedToSession = isAttachedToSession
     isAttachedToSession = true
+
+    if !wasAttachedToSession {
+      sessionAttachmentChangedCallback?(true)
+    }
 
     return result
   }
@@ -676,13 +693,16 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
     return _isPromptVisible
   }
 
-  func isNavigationUIEnabled() -> Bool {
+  public func isNavigationUIEnabled() -> Bool {
     _mapView.isNavigationEnabled
   }
 
   func setNavigationUIEnabled(_ enabled: Bool) {
     if _mapView.isNavigationEnabled != enabled {
       _mapView.isNavigationEnabled = enabled
+      if _isCarPlayView {
+        navigationUIEnabledChangedCallback?(enabled)
+      }
       if let viewId = _viewId {
         getViewEventApi()?
           .onNavigationUIEnabledChanged(viewId: viewId, navigationUIEnabled: enabled) { _ in }
@@ -1187,6 +1207,11 @@ extension GoogleMapsNavigationView: GMSMapViewDelegate {
         completion: { _ in }
       )
     }
+  }
+
+  func sendCustomNavigationAutoEventFromFlutter(event: String, data: Any) {
+    guard _isCarPlayView else { return }
+    customNavigationAutoEventFromFlutterCallback?(event, data)
   }
 }
 


### PR DESCRIPTION
Finalizes futter-to-native custom event delivery for auto views that was partailly implemented on release [0.9.3](https://github.com/googlemaps/flutter-navigation-sdk/releases/tag/0.9.3).
Adds helper method to refresh root template for Carplay views.

Fixes #714 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/