### PR TITLE
feat!: upgrade android sdk to 7.7.0 and ios sdk to 10.14.0

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -124,7 +124,7 @@ dependencies {
     implementation("androidx.car.app:app:1.7.0")
     implementation("androidx.car.app:app-projected:1.7.0")
     implementation("androidx.startup:startup-runtime:1.2.0")
-    implementation("com.google.android.libraries.navigation:navigation:7.6.1")
+    implementation("com.google.android.libraries.navigation:navigation:7.7.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("io.mockk:mockk:1.13.8")
     testImplementation("junit:junit:4.13.2")

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -107,8 +107,8 @@ flutter {
 dependencies {
     implementation("androidx.car.app:app:1.7.0")
     implementation("androidx.car.app:app-projected:1.7.0")
-    implementation("com.google.android.libraries.navigation:navigation:7.6.1")
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs_nio:2.0.4")
+    implementation("com.google.android.libraries.navigation:navigation:7.7.0")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs_nio:2.1.5")
     androidTestUtil("androidx.test:orchestrator:1.5.1")
 }
 

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -32,7 +32,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.13.0" apply false
+    id("com.android.application") version "8.13.2" apply false
     id("org.jetbrains.kotlin.android") version "2.3.20" apply false
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin") version "2.0.1" apply false
 }

--- a/ios/google_navigation_flutter.podspec
+++ b/ios/google_navigation_flutter.podspec
@@ -15,7 +15,7 @@ A Google Maps Navigation Flutter plugin.
   s.source           = { :path => '.' }
   s.source_files = 'google_navigation_flutter/Sources/google_navigation_flutter/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'GoogleNavigation', '10.13.0'
+  s.dependency 'GoogleNavigation', '10.14.0'
   s.platform = :ios, '16.0'
   s.static_framework = true
 

--- a/ios/google_navigation_flutter/Package.swift
+++ b/ios/google_navigation_flutter/Package.swift
@@ -29,11 +29,11 @@ let package = Package(
     .package(name: "FlutterFramework", path: "../FlutterFramework"),
     .package(
       url: "https://github.com/googlemaps/ios-navigation-sdk",
-      exact: "10.13.0"
+      exact: "10.14.0"
     ),
     .package(
       url: "https://github.com/googlemaps/ios-maps-sdk",
-      exact: "10.13.0"
+      exact: "10.14.0"
     ),
   ],
   targets: [


### PR DESCRIPTION
- Upgrades Google Maps Navigation SDK for Android to version 7.7.0
- Upgrades Google Maps Navigation SDK for iOS to version 10.14.0

BREAKING CHANGE: Updated the minimum Kotlin version to 2.3.0. 

Android SDK version 7.7.0 release notes are available at:
https://developers.google.com/maps/documentation/navigation/android-sdk/release-notes

iOS SDK version 10.14.0 release notes are available at:
https://developers.google.com/maps/documentation/navigation/ios-sdk/release-notes

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/