### PR TITLE
ci(dependabot): group updates and skip macOS CI jobs on bot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,34 +18,55 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     commit-message:
       prefix: chore(deps)
+    groups:
+      flutter-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "pub"
     directory: "/example" # Location of package manifests
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     commit-message:
       prefix: chore(deps)
+    groups:
+      example-flutter-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "gradle"
     directory: "/android" # Location of package manifests
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     commit-message:
       prefix: chore(deps)
+    groups:
+      android-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "gradle"
     directory: "/example/android" # Location of package manifests
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     commit-message:
       prefix: chore(deps)
+    groups:
+      example-android-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     commit-message:
       prefix: chore(deps)
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"
+

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -15,6 +15,12 @@
 name: Run tests and build
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/workflows/analyze.yaml'
+      - '.github/workflows/licence-check.yaml'
+      - '.github/workflows/release-please.yml'
   push:
     branches:
       - main
@@ -86,6 +92,7 @@ jobs:
 
   test-ios:
     name: Run iOS native unit tests
+    if: github.actor != 'dependabot[bot]'
     timeout-minutes: 45
     runs-on:
       labels: macos-26-xlarge
@@ -172,7 +179,7 @@ jobs:
   build-ios:
     name: Build iOS
     needs: [test-dart, test-ios]
-    if: contains(github.base_ref, 'main')
+    if: contains(github.base_ref, 'main') && github.actor != 'dependabot[bot]'
     timeout-minutes: 90
     runs-on:
       labels: macos-26-xlarge
@@ -319,7 +326,7 @@ jobs:
   integration-test-ios:
     name: Run iOS Integration Tests
     needs: [build-ios]
-    if: contains(github.base_ref, 'main')
+    if: contains(github.base_ref, 'main') && github.actor != 'dependabot[bot]'
     timeout-minutes: 90
     runs-on:
       labels: macos-26-xlarge


### PR DESCRIPTION
- Configure Dependabot to bundle dependency updates into weekly groups
- Limit concurrent open Dependabot pull requests to 3
- Bypass expensive iOS test and build jobs on macOS runners for Dependabot PRs
- Add path filtering to ignore markdown and unrelated workflow changes in CI