### PR TITLE
chore: update ci flutter to 3.44.x

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
-          flutter-version: "3.38.x"
+          flutter-version: "3.44.x"
           channel: "stable"
           cache: true
       - name: Setup melos
@@ -58,7 +58,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
-          flutter-version: "3.38.x"
+          flutter-version: "3.44.x"
           channel: "stable"
           cache: true
       - name: Setup melos

--- a/.github/workflows/licence-check.yaml
+++ b/.github/workflows/licence-check.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
-          flutter-version: "3.38.x"
+          flutter-version: "3.44.x"
           channel: "stable"
           cache: true
       - name: Install Melos

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         name: Setup flutter
         with:
-          flutter-version: "3.38.x"
+          flutter-version: "3.44.x"
           channel: "stable"
           cache: true
       - uses: bluefireteam/melos-action@6085791af7036f6366c9a4b9d55105c0ef9c6388
@@ -67,7 +67,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
-          flutter-version: "3.38.x"
+          flutter-version: "3.44.x"
           channel: "stable"
           cache: true
       - name: Setup melos
@@ -97,7 +97,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
-          flutter-version: "3.38.x"
+          flutter-version: "3.44.x"
           channel: "stable"
           cache: true
       - name: Setup melos
@@ -147,7 +147,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
-          flutter-version: "3.38.x"
+          flutter-version: "3.44.x"
           channel: "stable"
           cache: true
       - name: Setup melos
@@ -184,7 +184,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
-          flutter-version: "3.38.x"
+          flutter-version: "3.44.x"
           channel: "stable"
           cache: true
           architecture: x64
@@ -257,7 +257,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
-          flutter-version: "3.38.x"
+          flutter-version: "3.44.x"
           channel: "stable"
           cache: true
       - name: Download Build Artifact
@@ -340,7 +340,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
-          flutter-version: "3.38.x"
+          flutter-version: "3.44.x"
           channel: "stable"
           cache: true
       - name: Select XCode 26.5

--- a/example/lib/pages/navigation.dart
+++ b/example/lib/pages/navigation.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: experimental_member_use
+
 import 'dart:async';
 import 'dart:io';
 

--- a/example/patrol_test/t04_navigation_ui_test.dart
+++ b/example/patrol_test/t04_navigation_ui_test.dart
@@ -20,6 +20,8 @@
 // For more information about Flutter integration tests, please see
 // https://docs.flutter.dev/cookbook/testing/integration/introduction
 
+// ignore_for_file: experimental_member_use
+
 import 'package:flutter/material.dart';
 
 import 'shared.dart';


### PR DESCRIPTION
Update CI Flutter to version 3.44.x and fix `flutter analyze` errors that comes with it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/