### PR TITLE
fix: bind carplay screen to GMSMapView

### DIFF
--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/BaseCarSceneDelegate.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/BaseCarSceneDelegate.swift
@@ -148,7 +148,8 @@ open class BaseCarSceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate
             mapColorScheme: autoMapOptions?.mapColorScheme ?? .unspecified
           ),
           imageRegistry: imageRegistry,
-          isCarPlayView: true
+          isCarPlayView: true,
+          screen: templateApplicationScene.carWindow.screen
         )
 
         // Set up prompt visibility callback to allow override

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationView.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationView.swift
@@ -100,7 +100,8 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
     forceNightMode: GMSNavigationLightingMode?,
     mapConfiguration: MapConfiguration,
     imageRegistry: ImageRegistry,
-    isCarPlayView: Bool
+    isCarPlayView: Bool,
+    screen: UIScreen? = nil
   ) {
     if !isCarPlayView, viewId == nil || viewEventApi == nil {
       fatalError("For non-carplay map view viewId and viewEventApi is required")
@@ -117,6 +118,7 @@ public class GoogleMapsNavigationView: NSObject, FlutterPlatformView, ViewSettle
 
     let mapViewOptions = GMSMapViewOptions()
     _mapConfiguration.apply(to: mapViewOptions, withFrame: frame)
+    mapViewOptions.screen = screen
     _mapView = ViewStateAwareGMSMapView(options: mapViewOptions)
     _mapConfiguration.apply(to: _mapView)
 


### PR DESCRIPTION
Bind CarPlay screen to GMSMapView as instructed by the Google Navigation SDK documentation:
https://developers.google.com/maps/documentation/navigation/ios-sdk/reference/objc/Classes/GMSMapViewOptions#screen

Fixes: https://github.com/googlemaps/flutter-navigation-sdk/issues/739

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/