### PR TITLE
feat!: unify map padding to use density-independent pixels

### DIFF
--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/AndroidAutoBaseScreen.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/AndroidAutoBaseScreen.kt
@@ -20,6 +20,7 @@ import android.app.Presentation
 import android.graphics.Point
 import android.hardware.display.DisplayManager
 import android.hardware.display.VirtualDisplay
+import android.util.DisplayMetrics
 import androidx.car.app.AppManager
 import androidx.car.app.CarContext
 import androidx.car.app.Screen
@@ -225,6 +226,7 @@ open class AndroidAutoBaseScreen(carContext: CarContext) :
             imageRegistry,
             navigationView,
             googleMap,
+            surfaceContainer.dpi / DisplayMetrics.DENSITY_DEFAULT.toFloat(),
             onFlutterCustomNavigationAutoEvent = { event, data ->
               onCustomNavigationAutoEventFromFlutter(event, data)
             },

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/Convert.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/Convert.kt
@@ -16,7 +16,6 @@
 
 package com.google.maps.flutter.navigation
 
-import android.content.res.Resources
 import android.graphics.Point
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.GoogleMapOptions
@@ -184,10 +183,10 @@ object Convert {
    *
    * @param dx Delta on x-axis
    * @param dy Delta ony-axis
+   * @param density Display density used to convert logical pixels.
    * @return Android [Point].
    */
-  fun convertDeltaToPoint(dx: Double?, dy: Double?): Point? {
-    val density = Resources.getSystem().displayMetrics.density
+  fun convertDeltaToPoint(dx: Double?, dy: Double?, density: Float): Point? {
     var focus: Point? = null
     if (dx != null && dy != null) {
       focus =

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoMapView.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoMapView.kt
@@ -27,12 +27,15 @@ internal constructor(
   imageRegistry: ImageRegistry,
   override val navigationView: NavigationView,
   map: GoogleMap,
+  private val displayDensity: Float,
   private val onFlutterCustomNavigationAutoEvent: (String, Any) -> Unit,
 ) : GoogleMapsBaseNavigationView(null, mapOptions, null, imageRegistry) {
 
   override fun getView(): View {
     return navigationView
   }
+
+  override fun getDisplayDensity(): Float = displayDensity
 
   init {
     setMap(map)

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoViewMessageHandler.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsAutoViewMessageHandler.kt
@@ -16,8 +16,6 @@
 
 package com.google.maps.flutter.navigation
 
-import android.content.res.Resources
-
 /** GoogleMapsAutoViewMessageHandler */
 class GoogleMapsAutoViewMessageHandler(private val viewRegistry: GoogleMapsViewRegistry) :
   AutoMapViewApi {
@@ -253,7 +251,7 @@ class GoogleMapsAutoViewMessageHandler(private val viewRegistry: GoogleMapsViewR
     duration: Long?,
     callback: (Result<Boolean>) -> Unit,
   ) {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getView().getDisplayDensity()
     return getView()
       .animateCameraToLatLngBounds(
         Convert.convertLatLngBoundsFromDto(bounds),
@@ -292,7 +290,7 @@ class GoogleMapsAutoViewMessageHandler(private val viewRegistry: GoogleMapsViewR
     return getView()
       .animateCameraByZoom(
         zoomBy,
-        Convert.convertDeltaToPoint(focusDx, focusDy),
+        Convert.convertDeltaToPoint(focusDx, focusDy, getView().getDisplayDensity()),
         duration,
         callback,
       )
@@ -316,7 +314,7 @@ class GoogleMapsAutoViewMessageHandler(private val viewRegistry: GoogleMapsViewR
   }
 
   override fun moveCameraToLatLngBounds(bounds: LatLngBoundsDto, padding: Double) {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getView().getDisplayDensity()
     return getView()
       .moveCameraToLatLngBounds(
         Convert.convertLatLngBoundsFromDto(bounds),
@@ -333,7 +331,11 @@ class GoogleMapsAutoViewMessageHandler(private val viewRegistry: GoogleMapsViewR
   }
 
   override fun moveCameraByZoom(zoomBy: Double, focusDx: Double?, focusDy: Double?) {
-    return getView().moveCameraByZoom(zoomBy, Convert.convertDeltaToPoint(focusDx, focusDy))
+    return getView()
+      .moveCameraByZoom(
+        zoomBy,
+        Convert.convertDeltaToPoint(focusDx, focusDy, getView().getDisplayDensity()),
+      )
   }
 
   override fun moveCameraToZoom(zoom: Double) {

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsBaseMapView.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsBaseMapView.kt
@@ -17,7 +17,6 @@
 package com.google.maps.flutter.navigation
 
 import android.annotation.SuppressLint
-import android.content.res.Resources
 import android.graphics.Point
 import android.graphics.SurfaceTexture
 import android.location.Location
@@ -82,6 +81,9 @@ abstract class GoogleMapsBaseMapView(
   private var currentLifecycleState: LifecycleState = LifecycleState.NONE
 
   abstract fun getView(): View
+
+  /** Returns the density of the display rendering this map view. */
+  open fun getDisplayDensity(): Float = getView().resources.displayMetrics.density
 
   open fun onStart(): Boolean {
     if (
@@ -880,14 +882,14 @@ abstract class GoogleMapsBaseMapView(
   }
 
   fun getPolygons(): List<PolygonDto> {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getDisplayDensity()
     return _polygons.map {
       PolygonDto(it.polygonId, Convert.polygonToPolygonOptions(it.polygon, density))
     }
   }
 
   fun addPolygons(polygons: List<PolygonDto>): List<PolygonDto> {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getDisplayDensity()
     val result = mutableListOf<PolygonDto>()
     polygons.forEach {
       val builder = PolygonBuilder()
@@ -906,7 +908,7 @@ abstract class GoogleMapsBaseMapView(
   fun updatePolygons(polygons: List<PolygonDto>): List<PolygonDto> {
     var error: Throwable? = null
     val result = mutableListOf<PolygonDto>()
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getDisplayDensity()
     polygons.forEach {
       findPolygonController(it.polygonId)?.let { controller ->
         Convert.sinkPolygonOptions(it.options, controller, density)
@@ -943,14 +945,14 @@ abstract class GoogleMapsBaseMapView(
   }
 
   fun getPolylines(): List<PolylineDto> {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getDisplayDensity()
     return _polylines.map {
       PolylineDto(it.polylineId, Convert.polylineToPolylineOptions(it.polyline, density))
     }
   }
 
   fun addPolylines(polylines: List<PolylineDto>): List<PolylineDto> {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getDisplayDensity()
     val result = mutableListOf<PolylineDto>()
     polylines.forEach {
       val builder = PolylineBuilder()
@@ -968,7 +970,7 @@ abstract class GoogleMapsBaseMapView(
 
   fun updatePolylines(polylines: List<PolylineDto>): List<PolylineDto> {
     var error: Throwable? = null
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getDisplayDensity()
     val result = mutableListOf<PolylineDto>()
     polylines.forEach {
       findPolylineController(it.polylineId)?.let { controller ->
@@ -1005,14 +1007,14 @@ abstract class GoogleMapsBaseMapView(
   }
 
   fun getCircles(): List<CircleDto> {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getDisplayDensity()
     return _circles.map {
       CircleDto(it.circleId, Convert.circleToCircleOptions(it.circle, density))
     }
   }
 
   fun addCircles(circles: List<CircleDto>): List<CircleDto> {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getDisplayDensity()
     val result = mutableListOf<CircleDto>()
     circles.forEach {
       val builder = CircleBuilder()
@@ -1029,7 +1031,7 @@ abstract class GoogleMapsBaseMapView(
   }
 
   fun updateCircles(circles: List<CircleDto>): List<CircleDto> {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getDisplayDensity()
     val result = mutableListOf<CircleDto>()
     var error: Throwable? = null
     circles.forEach {
@@ -1112,7 +1114,7 @@ abstract class GoogleMapsBaseMapView(
 
   fun setPadding(padding: MapPaddingDto) {
     _mapOptions?.padding = padding
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getDisplayDensity()
     getMap()
       .setPadding(
         Convert.convertLogicalToScreenPixel(padding.left.toDouble(), density).roundToInt(),

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsBaseMapView.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsBaseMapView.kt
@@ -38,6 +38,7 @@ import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.Polygon
 import com.google.android.gms.maps.model.Polyline
+import kotlin.math.roundToInt
 
 abstract class GoogleMapsBaseMapView(
   private val viewId: Int?,
@@ -1111,12 +1112,13 @@ abstract class GoogleMapsBaseMapView(
 
   fun setPadding(padding: MapPaddingDto) {
     _mapOptions?.padding = padding
+    val density = Resources.getSystem().displayMetrics.density
     getMap()
       .setPadding(
-        padding.left.toInt(),
-        padding.top.toInt(),
-        padding.right.toInt(),
-        padding.bottom.toInt(),
+        Convert.convertLogicalToScreenPixel(padding.left.toDouble(), density).roundToInt(),
+        Convert.convertLogicalToScreenPixel(padding.top.toDouble(), density).roundToInt(),
+        Convert.convertLogicalToScreenPixel(padding.right.toDouble(), density).roundToInt(),
+        Convert.convertLogicalToScreenPixel(padding.bottom.toDouble(), density).roundToInt(),
       )
   }
 

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsViewMessageHandler.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsViewMessageHandler.kt
@@ -16,8 +16,6 @@
 
 package com.google.maps.flutter.navigation
 
-import android.content.res.Resources
-
 /** GoogleMapsViewMessageHandler */
 class GoogleMapsViewMessageHandler(private val viewRegistry: GoogleMapsViewRegistry) : MapViewApi {
 
@@ -203,7 +201,7 @@ class GoogleMapsViewMessageHandler(private val viewRegistry: GoogleMapsViewRegis
     duration: Long?,
     callback: (Result<Boolean>) -> Unit,
   ) {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getView(viewId.toInt()).getDisplayDensity()
     return getView(viewId.toInt())
       .animateCameraToLatLngBounds(
         Convert.convertLatLngBoundsFromDto(bounds),
@@ -245,7 +243,7 @@ class GoogleMapsViewMessageHandler(private val viewRegistry: GoogleMapsViewRegis
     return getView(viewId.toInt())
       .animateCameraByZoom(
         zoomBy,
-        Convert.convertDeltaToPoint(focusDx, focusDy),
+        Convert.convertDeltaToPoint(focusDx, focusDy, getView(viewId.toInt()).getDisplayDensity()),
         duration,
         callback,
       )
@@ -270,7 +268,7 @@ class GoogleMapsViewMessageHandler(private val viewRegistry: GoogleMapsViewRegis
   }
 
   override fun moveCameraToLatLngBounds(viewId: Long, bounds: LatLngBoundsDto, padding: Double) {
-    val density = Resources.getSystem().displayMetrics.density
+    val density = getView(viewId.toInt()).getDisplayDensity()
     return getView(viewId.toInt())
       .moveCameraToLatLngBounds(
         Convert.convertLatLngBoundsFromDto(bounds),
@@ -288,7 +286,10 @@ class GoogleMapsViewMessageHandler(private val viewRegistry: GoogleMapsViewRegis
 
   override fun moveCameraByZoom(viewId: Long, zoomBy: Double, focusDx: Double?, focusDy: Double?) {
     return getView(viewId.toInt())
-      .moveCameraByZoom(zoomBy, Convert.convertDeltaToPoint(focusDx, focusDy))
+      .moveCameraByZoom(
+        zoomBy,
+        Convert.convertDeltaToPoint(focusDx, focusDy, getView(viewId.toInt()).getDisplayDensity()),
+      )
   }
 
   override fun moveCameraToZoom(viewId: Long, zoom: Double) {

--- a/example/lib/pages/turn_by_turn.dart
+++ b/example/lib/pages/turn_by_turn.dart
@@ -15,7 +15,6 @@
 // ignore_for_file: public_member_api_docs
 
 import 'dart:async';
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:google_navigation_flutter/google_navigation_flutter.dart';
 
@@ -245,10 +244,6 @@ class _TurnByTurnPageState extends ExamplePageState<TurnByTurnPage> {
       padding = _getViewPadding();
     }
 
-    // On Android, scale padding by device pixel ratio
-    if (Platform.isAndroid) {
-      return padding * MediaQuery.of(context).devicePixelRatio;
-    }
     return padding;
   }
 

--- a/lib/src/google_maps_auto_view_controller.dart
+++ b/lib/src/google_maps_auto_view_controller.dart
@@ -394,14 +394,14 @@ class GoogleMapsAutoViewController {
     return GoogleMapsNavigationPlatform.instance.autoAPI.clear();
   }
 
-  /// Set padding for the map view.
+  /// Sets map-view padding in logical pixels.
   Future<void> setPadding(EdgeInsets padding) {
     return GoogleMapsNavigationPlatform.instance.autoAPI.setPadding(
       padding: padding,
     );
   }
 
-  // Gets the map padding from the map view.
+  /// Gets map-view padding in logical pixels.
   Future<EdgeInsets> getPadding() async {
     return GoogleMapsNavigationPlatform.instance.autoAPI.getPadding();
   }

--- a/lib/src/google_maps_map_view.dart
+++ b/lib/src/google_maps_map_view.dart
@@ -153,7 +153,7 @@ abstract class GoogleMapsBaseMapView extends StatefulWidget {
   /// Null by default (unbounded).
   final LatLngBounds? initialCameraTargetBounds;
 
-  /// Specifies the initial padding for the map view.
+  /// Specifies initial map-view padding in logical pixels.
   ///
   /// Null by default (no padding).
   final EdgeInsets? initialPadding;

--- a/lib/src/google_maps_map_view_controller.dart
+++ b/lib/src/google_maps_map_view_controller.dart
@@ -479,7 +479,7 @@ class GoogleMapViewController {
     return GoogleMapsNavigationPlatform.instance.viewAPI.clear(viewId: _viewId);
   }
 
-  /// Set padding for the map view.
+  /// Sets map-view padding in logical pixels.
   Future<void> setPadding(EdgeInsets padding) {
     return GoogleMapsNavigationPlatform.instance.viewAPI.setPadding(
       viewId: _viewId,
@@ -487,7 +487,7 @@ class GoogleMapViewController {
     );
   }
 
-  // Gets the map padding from the map view.
+  /// Gets map-view padding in logical pixels.
   Future<EdgeInsets> getPadding() async {
     return GoogleMapsNavigationPlatform.instance.viewAPI.getPadding(
       viewId: _viewId,

--- a/lib/src/types/view_initialization_options.dart
+++ b/lib/src/types/view_initialization_options.dart
@@ -197,7 +197,7 @@ class MapOptions {
   /// Null by default (unbounded).
   final LatLngBounds? cameraTargetBounds;
 
-  /// Specifies the initial padding for the map view.
+  /// Specifies initial map-view padding in logical pixels.
   ///
   /// Null by default (no padding).
   final EdgeInsets? padding;


### PR DESCRIPTION
BREAKING CHANGE: Unify map padding to use density independent pixels on Android so that padding for both platforms is the same.

Related: https://github.com/googlemaps/flutter-navigation-sdk/issues/478 https://github.com/googlemaps/flutter-navigation-sdk/issues/661

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [ ] I added new tests to check the change I am making
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/