### PR TITLE
fix(ios): hold navigation views weakly in the view registry so they deallocate on teardown

### DIFF
--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewRegistry.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewRegistry.swift
@@ -15,24 +15,8 @@
 import Dispatch
 import Foundation
 
-/// Weak wrapper so the registry does not own the views it tracks.
-///
-/// A `GoogleMapsNavigationView` removes itself from the registry only in its
-/// `deinit` (`unregisterView()`). If the registry held views strongly, that
-/// strong entry would keep the view's reference count above zero after Flutter
-/// tears down the platform view, so `deinit` would never run, the view would
-/// never be unregistered, and its underlying `GMSMapView` would be retained for
-/// the lifetime of the process. Because Flutter assigns a new view id for each
-/// platform view, nothing overwrites the stale entry either, so one view leaks
-/// per view creation. Holding views weakly lets a released view deallocate,
-/// which triggers `deinit` and prunes the (now-empty) entry.
-private class WeakViewRef {
-  weak var view: GoogleMapsNavigationView?
-  init(_ view: GoogleMapsNavigationView) { self.view = view }
-}
-
 class GoogleMapsNavigationViewRegistry {
-  private var views: [Int64: WeakViewRef] = [:]
+  private var viewRefs: [Int64: WeakRef<GoogleMapsNavigationView>] = [:]
   private var carPlayView: GoogleMapsNavigationView? {
     didSet {
       onHasCarPlayViewChanged?(carPlayView != nil)
@@ -50,46 +34,44 @@ class GoogleMapsNavigationViewRegistry {
 
   func registerView(viewId: Int64, view: GoogleMapsNavigationView) {
     queue.sync(flags: .barrier) { [weak self] in
-      self?.views[viewId] = WeakViewRef(view)
+      self?.viewRefs[viewId] = WeakRef(view)
     }
   }
 
   func unregisterView(viewId: Int64, viewInstanceIdToUnregister: ObjectIdentifier) {
     queue.async(flags: .barrier) { [weak self] in
       guard let self else { return }
-      // Remove the entry when it matches the unregistering instance, or when the
-      // weakly-held view has already been reclaimed, so stale keys never linger.
-      if let registeredView = self.views[viewId]?.view {
+      if let registeredView = self.viewRefs[viewId]?.value {
         if ObjectIdentifier(registeredView) == viewInstanceIdToUnregister {
-          self.views.removeValue(forKey: viewId)
+          self.viewRefs.removeValue(forKey: viewId)
         }
       } else {
-        self.views.removeValue(forKey: viewId)
+        self.viewRefs.removeValue(forKey: viewId)
       }
     }
   }
 
   func getView(viewId: Int64) -> GoogleMapsNavigationView? {
     queue.sync {
-      views[viewId]?.view
+      viewRefs[viewId]?.value
     }
   }
 
   func getAllRegisteredViewIds() -> [Int64] {
     queue.sync {
-      views.compactMap { $0.value.view != nil ? $0.key : nil }
+      viewRefs.compactMap { id, ref in ref.value != nil ? id : nil }
     }
   }
 
   func getAllRegisteredViews() -> [GoogleMapsNavigationView] {
     queue.sync {
-      views.values.compactMap { $0.view }
+      viewRefs.values.compactMap { $0.value }
     }
   }
 
   func getAllRegisteredNavigationViewIds() -> [Int64] {
     // Filter the views dictionary to include only those views that are navigation views
-    views.compactMap { $0.value.view?.isNavigationView() == true ? $0.key : nil }
+    viewRefs.compactMap { id, ref in ref.value?.isNavigationView() == true ? id : nil }
   }
 
   func registerCarPlayView(view: GoogleMapsNavigationView) {
@@ -116,7 +98,7 @@ class GoogleMapsNavigationViewRegistry {
 
   func sendPromptVisibilityChangedToAllViews(promptVisible: Bool) {
     queue.sync {
-      for view in views.values.compactMap({ $0.view }) {
+      for view in viewRefs.values.compactMap({ $0.value }) {
         view.sendPromptVisibilityChangedEvent(promptVisible: promptVisible)
       }
       // Also send to CarPlay view if it exists

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewRegistry.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationViewRegistry.swift
@@ -15,8 +15,24 @@
 import Dispatch
 import Foundation
 
+/// Weak wrapper so the registry does not own the views it tracks.
+///
+/// A `GoogleMapsNavigationView` removes itself from the registry only in its
+/// `deinit` (`unregisterView()`). If the registry held views strongly, that
+/// strong entry would keep the view's reference count above zero after Flutter
+/// tears down the platform view, so `deinit` would never run, the view would
+/// never be unregistered, and its underlying `GMSMapView` would be retained for
+/// the lifetime of the process. Because Flutter assigns a new view id for each
+/// platform view, nothing overwrites the stale entry either, so one view leaks
+/// per view creation. Holding views weakly lets a released view deallocate,
+/// which triggers `deinit` and prunes the (now-empty) entry.
+private class WeakViewRef {
+  weak var view: GoogleMapsNavigationView?
+  init(_ view: GoogleMapsNavigationView) { self.view = view }
+}
+
 class GoogleMapsNavigationViewRegistry {
-  private var views: [Int64: GoogleMapsNavigationView] = [:]
+  private var views: [Int64: WeakViewRef] = [:]
   private var carPlayView: GoogleMapsNavigationView? {
     didSet {
       onHasCarPlayViewChanged?(carPlayView != nil)
@@ -34,41 +50,46 @@ class GoogleMapsNavigationViewRegistry {
 
   func registerView(viewId: Int64, view: GoogleMapsNavigationView) {
     queue.sync(flags: .barrier) { [weak self] in
-      self?.views[viewId] = view
+      self?.views[viewId] = WeakViewRef(view)
     }
   }
 
   func unregisterView(viewId: Int64, viewInstanceIdToUnregister: ObjectIdentifier) {
     queue.async(flags: .barrier) { [weak self] in
-      if let registeredView = self?.views[viewId],
-        ObjectIdentifier(registeredView) == viewInstanceIdToUnregister
-      {
-        self?.views.removeValue(forKey: viewId)
+      guard let self else { return }
+      // Remove the entry when it matches the unregistering instance, or when the
+      // weakly-held view has already been reclaimed, so stale keys never linger.
+      if let registeredView = self.views[viewId]?.view {
+        if ObjectIdentifier(registeredView) == viewInstanceIdToUnregister {
+          self.views.removeValue(forKey: viewId)
+        }
+      } else {
+        self.views.removeValue(forKey: viewId)
       }
     }
   }
 
   func getView(viewId: Int64) -> GoogleMapsNavigationView? {
     queue.sync {
-      views[viewId]
+      views[viewId]?.view
     }
   }
 
   func getAllRegisteredViewIds() -> [Int64] {
     queue.sync {
-      Array(views.keys)
+      views.compactMap { $0.value.view != nil ? $0.key : nil }
     }
   }
 
   func getAllRegisteredViews() -> [GoogleMapsNavigationView] {
     queue.sync {
-      Array(views.values)
+      views.values.compactMap { $0.view }
     }
   }
 
   func getAllRegisteredNavigationViewIds() -> [Int64] {
     // Filter the views dictionary to include only those views that are navigation views
-    views.filter { $0.value.isNavigationView() }.map(\.key)
+    views.compactMap { $0.value.view?.isNavigationView() == true ? $0.key : nil }
   }
 
   func registerCarPlayView(view: GoogleMapsNavigationView) {
@@ -95,7 +116,7 @@ class GoogleMapsNavigationViewRegistry {
 
   func sendPromptVisibilityChangedToAllViews(promptVisible: Bool) {
     queue.sync {
-      for view in views.values {
+      for view in views.values.compactMap({ $0.view }) {
         view.sendPromptVisibilityChangedEvent(promptVisible: promptVisible)
       }
       // Also send to CarPlay view if it exists

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/Utilities.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/Utilities.swift
@@ -14,6 +14,14 @@
 
 import UIKit
 
+final class WeakRef<T: AnyObject> {
+  weak var value: T?
+
+  init(_ value: T) {
+    self.value = value
+  }
+}
+
 extension String {
   static var empty: String { "" }
 }


### PR DESCRIPTION
## Summary

On iOS, every `GoogleMapsMapView` / `GoogleMapsNavigationView` is retained for the lifetime of the process, so repeatedly creating and disposing map/nav views grows memory without bound and eventually leads to jetsam/`WatchdogTermination` on memory-constrained devices.

`GoogleMapsNavigationViewRegistry` stored views in a **strong** dictionary:
```swift
private var views: [Int64: GoogleMapsNavigationView] = [:]
```
but a view removes itself from the registry **only in its `deinit`** (`unregisterView()`). The strong entry keeps the view's reference count above zero after Flutter tears down the platform view, so `deinit` never runs, `unregisterView()` is never called, and the view (and its underlying `GMSMapView`) leaks forever. Flutter assigns a new `viewId` per platform-view creation, so nothing overwrites the stale entry either — **one view leaks per view creation.**

This is a self-referential retain: the only code that removes a view from the registry runs in `deinit`, which the registry's own strong reference prevents from ever running.

## Fix

Hold views through a small `WeakViewRef` wrapper instead of strongly. A released view then deallocates, `deinit` runs, and the entry is pruned. `unregisterView` also removes entries whose weak reference has already been reclaimed, so stale keys can't accumulate. All read accessors `compactMap` over live views.

CarPlay handling is unchanged: `carPlayView` has an explicit `unregisterCarPlayView()` call path (from `BaseCarSceneDelegate`) and never depended on `deinit`, so it was not affected by this leak.

## Reproduction / verification

1. Show a screen containing a `GoogleMapsMapView`, dismiss it, repeat.
2. Profile in Instruments (Activity Monitor) on a physical device.

Measured on an iPhone 11 / iOS 26.5: **physical footprint climbed ~85 MB → ~595 MB over ~4.5 min** of open/close cycles with no reclamation (~88 MB/min) before the change; after the change it reclaims between cycles.

Present at least through 0.9.4 and 0.10.0 (identical registry code).
