### PR TITLE
feat: report heading and speed with road-snapped locations

### DIFF
--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsNavigationSessionManager.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/GoogleMapsNavigationSessionManager.kt
@@ -909,13 +909,20 @@ constructor(
         object : RoadSnappedLocationProvider.GpsAvailabilityEnhancedLocationListener {
           override fun onLocationChanged(location: Location) {
             navigationSessionEventApi.onRoadSnappedLocationUpdated(
-              LatLngDto(location.latitude, location.longitude)
+              LatLngDto(location.latitude, location.longitude),
+              // A Location without a bearing or a speed still answers 0f for
+              // both. Passed on as-is, a stationary device would read as
+              // heading due north, so an absent value is sent as null.
+              if (location.hasBearing()) location.bearing.toDouble() else null,
+              if (location.hasSpeed()) location.speed.toDouble() else null
             ) {}
           }
 
           override fun onRawLocationUpdate(location: Location) {
             navigationSessionEventApi.onRoadSnappedRawLocationUpdated(
-              LatLngDto(location.latitude, location.longitude)
+              LatLngDto(location.latitude, location.longitude),
+              if (location.hasBearing()) location.bearing.toDouble() else null,
+              if (location.hasSpeed()) location.speed.toDouble() else null
             ) {}
           }
 

--- a/android/src/main/kotlin/com/google/maps/flutter/navigation/messages.g.kt
+++ b/android/src/main/kotlin/com/google/maps/flutter/navigation/messages.g.kt
@@ -7881,13 +7881,18 @@ class NavigationSessionEventApi(
     }
   }
 
-  fun onRoadSnappedLocationUpdated(locationArg: LatLngDto, callback: (Result<Unit>) -> Unit) {
+  fun onRoadSnappedLocationUpdated(
+    locationArg: LatLngDto,
+    headingArg: Double?,
+    speedArg: Double?,
+    callback: (Result<Unit>) -> Unit,
+  ) {
     val separatedMessageChannelSuffix =
       if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
     val channelName =
       "dev.flutter.pigeon.google_navigation_flutter.NavigationSessionEventApi.onRoadSnappedLocationUpdated$separatedMessageChannelSuffix"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(locationArg)) {
+    channel.send(listOf(locationArg, headingArg, speedArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
           callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
@@ -7900,13 +7905,18 @@ class NavigationSessionEventApi(
     }
   }
 
-  fun onRoadSnappedRawLocationUpdated(locationArg: LatLngDto, callback: (Result<Unit>) -> Unit) {
+  fun onRoadSnappedRawLocationUpdated(
+    locationArg: LatLngDto,
+    headingArg: Double?,
+    speedArg: Double?,
+    callback: (Result<Unit>) -> Unit,
+  ) {
     val separatedMessageChannelSuffix =
       if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
     val channelName =
       "dev.flutter.pigeon.google_navigation_flutter.NavigationSessionEventApi.onRoadSnappedRawLocationUpdated$separatedMessageChannelSuffix"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(locationArg)) {
+    channel.send(listOf(locationArg, headingArg, speedArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
           callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationSessionManager.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/GoogleMapsNavigationSessionManager.swift
@@ -594,6 +594,11 @@ extension GoogleMapsNavigationSessionManager: GMSRoadSnappedLocationProviderList
           latitude: location.coordinate.latitude,
           longitude: location.coordinate.longitude
         ),
+      // CLLocation reports an unavailable course or speed as a negative
+      // value. Passed on as-is a stationary device would read as heading
+      // due north at negative speed, so those arrive as nil instead.
+      heading: location.course >= 0 ? location.course : nil,
+      speed: location.speed >= 0 ? location.speed : nil,
       completion: { _ in }
     )
   }

--- a/ios/google_navigation_flutter/Sources/google_navigation_flutter/messages.g.swift
+++ b/ios/google_navigation_flutter/Sources/google_navigation_flutter/messages.g.swift
@@ -6605,9 +6605,11 @@ protocol NavigationSessionEventApiProtocol {
   func onSpeedingUpdated(
     msg msgArg: SpeedingUpdatedEventDto, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onRoadSnappedLocationUpdated(
-    location locationArg: LatLngDto, completion: @escaping (Result<Void, PigeonError>) -> Void)
+    location locationArg: LatLngDto, heading headingArg: Double?, speed speedArg: Double?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onRoadSnappedRawLocationUpdated(
-    location locationArg: LatLngDto, completion: @escaping (Result<Void, PigeonError>) -> Void)
+    location locationArg: LatLngDto, heading headingArg: Double?, speed speedArg: Double?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onArrival(
     waypoint waypointArg: NavigationWaypointDto,
     completion: @escaping (Result<Void, PigeonError>) -> Void)
@@ -6667,13 +6669,14 @@ class NavigationSessionEventApi: NavigationSessionEventApiProtocol {
     }
   }
   func onRoadSnappedLocationUpdated(
-    location locationArg: LatLngDto, completion: @escaping (Result<Void, PigeonError>) -> Void
+    location locationArg: LatLngDto, heading headingArg: Double?, speed speedArg: Double?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void
   ) {
     let channelName: String =
       "dev.flutter.pigeon.google_navigation_flutter.NavigationSessionEventApi.onRoadSnappedLocationUpdated\(messageChannelSuffix)"
     let channel = FlutterBasicMessageChannel(
       name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([locationArg] as [Any?]) { response in
+    channel.sendMessage([locationArg, headingArg, speedArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
         return
@@ -6689,13 +6692,14 @@ class NavigationSessionEventApi: NavigationSessionEventApiProtocol {
     }
   }
   func onRoadSnappedRawLocationUpdated(
-    location locationArg: LatLngDto, completion: @escaping (Result<Void, PigeonError>) -> Void
+    location locationArg: LatLngDto, heading headingArg: Double?, speed speedArg: Double?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void
   ) {
     let channelName: String =
       "dev.flutter.pigeon.google_navigation_flutter.NavigationSessionEventApi.onRoadSnappedRawLocationUpdated\(messageChannelSuffix)"
     let channel = FlutterBasicMessageChannel(
       name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([locationArg] as [Any?]) { response in
+    channel.sendMessage([locationArg, headingArg, speedArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
         return

--- a/lib/src/method_channel/messages.g.dart
+++ b/lib/src/method_channel/messages.g.dart
@@ -9078,9 +9078,17 @@ abstract class NavigationSessionEventApi {
 
   void onSpeedingUpdated(SpeedingUpdatedEventDto msg);
 
-  void onRoadSnappedLocationUpdated(LatLngDto location);
+  void onRoadSnappedLocationUpdated(
+    LatLngDto location,
+    double? heading,
+    double? speed,
+  );
 
-  void onRoadSnappedRawLocationUpdated(LatLngDto location);
+  void onRoadSnappedRawLocationUpdated(
+    LatLngDto location,
+    double? heading,
+    double? speed,
+  );
 
   void onArrival(NavigationWaypointDto waypoint);
 
@@ -9175,8 +9183,14 @@ abstract class NavigationSessionEventApi {
             arg_location != null,
             'Argument for dev.flutter.pigeon.google_navigation_flutter.NavigationSessionEventApi.onRoadSnappedLocationUpdated was null, expected non-null LatLngDto.',
           );
+          final double? arg_heading = (args[1] as double?);
+          final double? arg_speed = (args[2] as double?);
           try {
-            api.onRoadSnappedLocationUpdated(arg_location!);
+            api.onRoadSnappedLocationUpdated(
+              arg_location!,
+              arg_heading,
+              arg_speed,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
@@ -9209,8 +9223,14 @@ abstract class NavigationSessionEventApi {
             arg_location != null,
             'Argument for dev.flutter.pigeon.google_navigation_flutter.NavigationSessionEventApi.onRoadSnappedRawLocationUpdated was null, expected non-null LatLngDto.',
           );
+          final double? arg_heading = (args[1] as double?);
+          final double? arg_speed = (args[2] as double?);
           try {
-            api.onRoadSnappedRawLocationUpdated(arg_location!);
+            api.onRoadSnappedRawLocationUpdated(
+              arg_location!,
+              arg_heading,
+              arg_speed,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/lib/src/method_channel/session_api.dart
+++ b/lib/src/method_channel/session_api.dart
@@ -761,17 +761,33 @@ class NavigationSessionEventApiImpl implements NavigationSessionEventApi {
   }
 
   @override
-  void onRoadSnappedLocationUpdated(LatLngDto location) {
+  void onRoadSnappedLocationUpdated(
+    LatLngDto location,
+    double? heading,
+    double? speed,
+  ) {
     sessionEventStreamController.add(
-      RoadSnappedLocationUpdatedEvent(location: location.toLatLng()),
+      RoadSnappedLocationUpdatedEvent(
+        location: location.toLatLng(),
+        heading: heading,
+        speed: speed,
+      ),
     );
   }
 
   // Android only.
   @override
-  void onRoadSnappedRawLocationUpdated(LatLngDto location) {
+  void onRoadSnappedRawLocationUpdated(
+    LatLngDto location,
+    double? heading,
+    double? speed,
+  ) {
     sessionEventStreamController.add(
-      RoadSnappedRawLocationUpdatedEvent(location: location.toLatLng()),
+      RoadSnappedRawLocationUpdatedEvent(
+        location: location.toLatLng(),
+        heading: heading,
+        speed: speed,
+      ),
     );
   }
 

--- a/lib/src/types/navigation.dart
+++ b/lib/src/types/navigation.dart
@@ -58,27 +58,59 @@ class SpeedingUpdatedEvent {
 /// {@category Navigation}
 class RoadSnappedLocationUpdatedEvent {
   /// Initialize road snapped location updated event message.
-  RoadSnappedLocationUpdatedEvent({required this.location});
+  RoadSnappedLocationUpdatedEvent({
+    required this.location,
+    this.heading,
+    this.speed,
+  });
 
   /// Coordinate of the updated location.
   final LatLng location;
 
+  /// Direction of travel in degrees clockwise from true north, or null where
+  /// the platform reports none.
+  ///
+  /// A stationary device has no direction to report, and neither platform
+  /// invents one: iOS leaves `CLLocation.course` negative and Android leaves
+  /// `Location.hasBearing()` false. Both arrive here as null rather than as
+  /// zero, which would read as due north.
+  final double? heading;
+
+  /// Speed over ground in metres per second, or null where the platform
+  /// reports none. Negative iOS values and absent Android values are null.
+  final double? speed;
+
   @override
-  String toString() => 'RoadSnappedLocationUpdatedEvent(location: $location)';
+  String toString() =>
+      'RoadSnappedLocationUpdatedEvent(location: $location, '
+      'heading: $heading, speed: $speed)';
 }
 
 /// RoadSnappedRawLocationUpdated event message (Android only).
 /// {@category Navigation}
 class RoadSnappedRawLocationUpdatedEvent {
   /// Initialize road snapped raw location updated event message.
-  RoadSnappedRawLocationUpdatedEvent({required this.location});
+  RoadSnappedRawLocationUpdatedEvent({
+    required this.location,
+    this.heading,
+    this.speed,
+  });
 
   /// Coordinate of the updated location.
   final LatLng location;
 
+  /// Direction of travel in degrees clockwise from true north, or null where
+  /// the platform reports none. See [RoadSnappedLocationUpdatedEvent.heading].
+  final double? heading;
+
+  /// Speed over ground in metres per second, or null where the platform
+  /// reports none. See [RoadSnappedLocationUpdatedEvent.speed].
+  final double? speed;
+
   @override
   String toString() =>
-      'RoadSnappedRawLocationUpdatedEvent(location: $location)';
+      'RoadSnappedRawLocationUpdatedEvent(location: $location, '
+      'heading: $heading, speed: $speed)';
 }
 
 /// GpsAvailabilityUpdated event message (Android only).

--- a/pigeons/messages.dart
+++ b/pigeons/messages.dart
@@ -1617,8 +1617,16 @@ abstract class NavigationSessionApi {
 @FlutterApi()
 abstract class NavigationSessionEventApi {
   void onSpeedingUpdated(SpeedingUpdatedEventDto msg);
-  void onRoadSnappedLocationUpdated(LatLngDto location);
-  void onRoadSnappedRawLocationUpdated(LatLngDto location);
+  void onRoadSnappedLocationUpdated(
+    LatLngDto location,
+    double? heading,
+    double? speed,
+  );
+  void onRoadSnappedRawLocationUpdated(
+    LatLngDto location,
+    double? heading,
+    double? speed,
+  );
   void onArrival(NavigationWaypointDto waypoint);
   void onRouteChanged();
   void onRemainingTimeOrDistanceChanged(

--- a/test/navigation_session/navigation_session_event_api_test.dart
+++ b/test/navigation_session/navigation_session_event_api_test.dart
@@ -112,9 +112,13 @@ void main() {
       // Emit test events via DTO
       testSessionApi.testEventApi.onRoadSnappedLocationUpdated(
         LatLngDto(latitude: 37.4220, longitude: -122.0841),
+        90.0,
+        12.5,
       );
       testSessionApi.testEventApi.onRoadSnappedLocationUpdated(
         LatLngDto(latitude: 37.4225, longitude: -122.0845),
+        null,
+        null,
       );
 
       await Future<void>.delayed(const Duration(milliseconds: 50));
@@ -124,6 +128,12 @@ void main() {
       expect(receivedEvents[0].location.longitude, -122.0841);
       expect(receivedEvents[1].location.latitude, 37.4225);
       expect(receivedEvents[1].location.longitude, -122.0845);
+      expect(receivedEvents[0].heading, 90.0);
+      expect(receivedEvents[0].speed, 12.5);
+      // A platform that reports no course or speed must not be read as
+      // heading due north at a standstill.
+      expect(receivedEvents[1].heading, isNull);
+      expect(receivedEvents[1].speed, isNull);
 
       await subscription.cancel();
     });
@@ -142,6 +152,8 @@ void main() {
       // Emit test event via DTO
       testSessionApi.testEventApi.onRoadSnappedRawLocationUpdated(
         LatLngDto(latitude: 40.7128, longitude: -74.0060),
+        180.0,
+        3.0,
       );
 
       await Future<void>.delayed(const Duration(milliseconds: 50));
@@ -149,6 +161,8 @@ void main() {
       expect(receivedEvents.length, 1);
       expect(receivedEvents[0].location.latitude, 40.7128);
       expect(receivedEvents[0].location.longitude, -74.0060);
+      expect(receivedEvents[0].heading, 180.0);
+      expect(receivedEvents[0].speed, 3.0);
 
       await subscription.cancel();
     });


### PR DESCRIPTION
Road-snapped location events now carry the heading and speed the platform
location already reports.

Both native callbacks receive a full platform location — `CLLocation` on iOS,
`Location` on Android — and forwarded only the coordinate. An app drawing its
own location marker on top of the navigation session therefore had no direction
to orient it by, and had to infer a bearing from consecutive points, which is
unreliable at low speed and visibly wrong when stationary.

`RoadSnappedLocationUpdatedEvent` and `RoadSnappedRawLocationUpdatedEvent` gain
`heading` and `speed`.

Both are nullable, because both platforms have a way of saying they do not know:
iOS leaves `CLLocation.course` and `.speed` negative, Android leaves
`hasBearing()` and `hasSpeed()` false. Those map to `null` rather than to `0`,
which a consumer would otherwise read as heading due north at a standstill.

Fixes #760

### On the generated files

Regenerating with the pinned `pigeon: 25.3.2` reproduces the Dart and Swift
output exactly, but the checked-in `messages.g.kt` differs by ~550 lines of
reflow from what `ktfmt --google-style` produces here — the ktfmt bundled by
`com.ncorti.ktfmt.gradle:0.21.0` appears to be older than the CLI available to
me. Verified by regenerating and formatting the unchanged input, which shows the
same ~550 lines. Rather than carry that into this PR, `messages.g.kt` holds only
the two hunks this change implies. It should regenerate cleanly in your CI.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation
- [x] I added new tests to check the change I am making
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/googlemaps/flutter-navigation-sdk/blob/main/CONTRIBUTING.md
[CLA]: https://cla.developers.google.com/
